### PR TITLE
Added Accessibility Support for Upper Ribbon and Lower Ribbon tabs with Keyboard Navigation

### DIFF
--- a/src/components/GoXLR.vue
+++ b/src/components/GoXLR.vue
@@ -1,122 +1,118 @@
 <template>
+    <div id="main">
+        <DeviceSelector v-if="!isDeviceSet()" />
 
-  <div id="main">
-    <DeviceSelector v-if="!isDeviceSet()"/>
+        <template v-if="isDeviceSet()">
+            <div style="display: flex; flex-direction: row; column-gap: 30px">
+                <div>
+                    <FileTabs />
+                </div>
+            </div>
 
-    <template v-if="isDeviceSet()">
-      <div style="display: flex; flex-direction: row; column-gap: 30px">
-        <div>
-          <FileTabs/>
-        </div>
+            <div style="height: 25px; background-color: #3b413f" />
 
-      </div>
-
-      <div style="height: 25px; background-color: #3b413f"/>
-
-      <Tabs>
-        <Tab name="Mic">
-          <Mic/>
-        </Tab>
-        <Tab name="Mixer" selected>
-          <ContentContainer>
-            <Mixer/>
-          </ContentContainer>
-        </Tab>
-        <Tab name="Configuration">
-          <ContentContainer>
-            <CenteredContainer>
-              <Faders/>
-              <Cough/>
-            </CenteredContainer>
-          </ContentContainer>
-        </Tab>
-        <Tab v-if="!isDeviceMini()" name="Effects">
-          <EffectsTab/>
-        </Tab>
-        <Tab v-if="!isDeviceMini()" name="Sampler">
-          <ContentContainer>
-            <SamplerTab/>
-          </ContentContainer>
-        </Tab>
-        <Tab name="Lighting">
-          <LightingTab/>
-        </Tab>
-        <Tab name="Routing">
-          <ContentContainer>
-            <Routing/>
-          </ContentContainer>
-        </Tab>
-        <Tab name="System">
-          <ContentContainer>
-            <SystemComponent/>
-          </ContentContainer>
-        </Tab>
-      </Tabs>
-    </template>
-  </div>
-
+            <Tabs label="Lower Ribbon">
+                <Tab name="Mic">
+                    <Mic />
+                </Tab>
+                <Tab name="Mixer" selected>
+                    <ContentContainer>
+                        <Mixer />
+                    </ContentContainer>
+                </Tab>
+                <Tab name="Configuration">
+                    <ContentContainer>
+                        <CenteredContainer>
+                            <Faders />
+                            <Cough />
+                        </CenteredContainer>
+                    </ContentContainer>
+                </Tab>
+                <Tab v-if="!isDeviceMini()" name="Effects">
+                    <EffectsTab />
+                </Tab>
+                <Tab v-if="!isDeviceMini()" name="Sampler">
+                    <ContentContainer>
+                        <SamplerTab />
+                    </ContentContainer>
+                </Tab>
+                <Tab name="Lighting">
+                    <LightingTab />
+                </Tab>
+                <Tab name="Routing">
+                    <ContentContainer>
+                        <Routing />
+                    </ContentContainer>
+                </Tab>
+                <Tab name="System">
+                    <ContentContainer>
+                        <SystemComponent />
+                    </ContentContainer>
+                </Tab>
+            </Tabs>
+        </template>
+    </div>
 </template>
 
 <script>
-
-import Faders from "./sections/Faders"
+import Faders from "./sections/Faders";
 import Mixer from "./sections/Mixer";
 import Tabs from "@/components/tabs/Tabs";
 import Tab from "@/components/tabs/Tab";
 import Routing from "@/components/sections/Routing";
 import Mic from "@/components/sections/Mic";
 import DeviceSelector from "@/components/sections/DeviceSelector";
-import {store} from "@/store";
+import { store } from "@/store";
 import Cough from "@/components/sections/Cough";
-import {websocket} from "@/util/sockets";
+import { websocket } from "@/util/sockets";
 import SystemComponent from "@/components/sections/System";
 import FileTabs from "@/components/sections/files/FileTabs";
 import EffectsTab from "@/components/sections/EffectsTab";
-import {isDeviceMini} from "@/util/util";
+import { isDeviceMini } from "@/util/util";
 import LightingTab from "@/components/sections/lighting/LightingTab";
 import SamplerTab from "@/components/sections/SamplerTab";
 import ContentContainer from "@/components/containers/ContentContainer.vue";
 import CenteredContainer from "@/components/containers/CenteredContainer.vue";
 
 export default {
-  name: 'GoXLR',
-  components: {
-    CenteredContainer,
-    ContentContainer,
-    SamplerTab,
-    LightingTab,
-    EffectsTab,
-    FileTabs,
-    SystemComponent,
-    Cough,
-    DeviceSelector,
-    Routing,
-    Tab,
-    Tabs,
-    Mixer,
-    Faders,
-    Mic
-  },
-
-  methods: {
-    isDeviceMini,
-
-    isDeviceSet() {
-      return (store.hasActiveDevice() && store.isConnected());
+    name: "GoXLR",
+    components: {
+        CenteredContainer,
+        ContentContainer,
+        SamplerTab,
+        LightingTab,
+        EffectsTab,
+        FileTabs,
+        SystemComponent,
+        Cough,
+        DeviceSelector,
+        Routing,
+        Tab,
+        Tabs,
+        Mixer,
+        Faders,
+        Mic,
     },
-  },
 
-  created() {
-    websocket.get_status().then((data) => {
-      store.replaceData(data);
-    });
-  },
-}
+    methods: {
+        isDeviceMini,
+
+        isDeviceSet() {
+            return store.hasActiveDevice() && store.isConnected();
+        },
+    },
+
+    created() {
+        websocket.get_status().then((data) => {
+            store.replaceData(data);
+        });
+    },
+};
 </script>
 
 <style scoped>
 #main {
-  width: 100%;
-  font-size: 10pt;
+    width: 100%;
+    font-size: 10pt;
 }
 </style>

--- a/src/components/sections/files/FileTabs.vue
+++ b/src/components/sections/files/FileTabs.vue
@@ -1,15 +1,15 @@
 <template>
-  <Tabs style="width: 480px">
-    <Tab name="Profiles" :selected="true">
-      <ProfileHandler/>
-    </Tab>
-    <Tab v-if="!isDeviceMini()" name="Samples">
-      <SampleHandler/>
-    </Tab>
-    <Tab v-if="!isDeviceMini()" name="Presets">
-      <PresetHandler/>
-    </Tab>
-  </Tabs>
+    <Tabs style="width: 480px" label="Upper Ribbon">
+        <Tab name="Profiles" :selected="true">
+            <ProfileHandler />
+        </Tab>
+        <Tab v-if="!isDeviceMini()" name="Samples">
+            <SampleHandler />
+        </Tab>
+        <Tab v-if="!isDeviceMini()" name="Presets">
+            <PresetHandler />
+        </Tab>
+    </Tabs>
 </template>
 
 <script>
@@ -18,17 +18,15 @@ import Tab from "@/components/tabs/Tab";
 import ProfileHandler from "@/components/profiles/handlers/ProfileHandler";
 import PresetHandler from "@/components/sections/files/PresetHandler";
 import SampleHandler from "@/components/sections/files/SampleHandler";
-import {isDeviceMini} from "@/util/util";
+import { isDeviceMini } from "@/util/util";
 
 export default {
-  name: "FileTabs",
-  methods: {
-    isDeviceMini
-  },
-  components: {SampleHandler, PresetHandler, ProfileHandler, Tabs, Tab},
-}
+    name: "FileTabs",
+    methods: {
+        isDeviceMini,
+    },
+    components: { SampleHandler, PresetHandler, ProfileHandler, Tabs, Tab },
+};
 </script>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -1,77 +1,131 @@
 <template>
-  <div style="margin-left: 8px; margin-right: 8px">
-    <div class="tab">
-      <button v-for="tab in tabs" :key="tab.name" :class="{ 'active': tab.isActive }" v-show="!tab.hidden" @click="selectTab(tab)">{{tab.name}}</button>
+    <div style="margin-left: 8px; margin-right: 8px">
+        <div class="tab" role="TabList" :aria-label="this.label">
+            <button
+                v-for="tab in tabs"
+                :key="tab.name"
+                :class="{ active: tab.isActive }"
+                v-show="!tab.hidden"
+                @click="selectTab(tab)"
+                role="tab"
+                :aria-selected="tab.isActive"
+                :tabindex="tab.isActive ? 0 : -1"
+                @keydown="onTabKeydown"
+                :ref="tab.name"
+            >
+                {{ tab.name }}
+            </button>
+        </div>
+        <div
+            class="tabs-details"
+            role="tabpanel"
+            :aria-label="getActiveTab().name"
+        >
+            <slot></slot>
+        </div>
     </div>
-    <div class="tabs-details">
-      <slot></slot>
-    </div>
-  </div>
 </template>
 
 <script>
 export default {
-  name: "TabList",
+    name: "TabList",
 
-  data() {
-    return {tabs: []};
-  },
+    data() {
+        return { tabs: [] };
+    },
+    props: {
+        label: {
+            type: String,
+            required: false,
+            default: "Tab list",
+        },
+    },
 
-  created() {
+    created() {},
 
-  },
+    methods: {
+        selectTab(selectedTab) {
+            this.tabs.forEach((tab) => {
+                tab.isActive = tab.name === selectedTab.name;
+            });
+        },
+        getActiveTab() {
+            //return the active tab
+            const activeTab = this.tabs.find((tab) => tab.isActive);
+            if (activeTab) {
+                return activeTab;
+            } else {
+                return "";
+            }
+        },
+        //keyboard navigation
+        onTabKeydown(event) {
+            const tabs = this.tabs;
+            const activeTab = this.getActiveTab();
+            const activeTabIndex = tabs.indexOf(activeTab);
+            let nextTab;
 
-  methods: {
-    selectTab(selectedTab) {
-      this.tabs.forEach(tab => {
-        tab.isActive = (tab.name === selectedTab.name)
-      });
-    }
-  }
-}
+            if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+                nextTab = tabs[(activeTabIndex + 1) % tabs.length];
+                //explanation: if activeTabIndex is 0, then 0+1 % 3 = 1, so nextTab is tabs[1]
+            } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+                nextTab =
+                    tabs[(activeTabIndex - 1 + tabs.length) % tabs.length];
+                //explanation: if activeTabIndex is 0, then 0-1+3 % 3 = 2, so nextTab is tabs[2]
+            } else if (event.key === "Home") {
+                nextTab = tabs[0];
+            } else if (event.key === "End") {
+                nextTab = tabs[tabs.length - 1];
+            }
+
+            if (nextTab) {
+                this.selectTab(nextTab);
+                //nextTab.$el is the button element
+                //we need a ref on the button element to focus it
+                this.$refs[nextTab.name][0].focus();
+            }
+        },
+    },
+};
 </script>
 
 <style>
 .tab {
-  border-bottom: 1px solid #59b1b6;
-  text-align: left;
+    border-bottom: 1px solid #59b1b6;
+    text-align: left;
 }
 
 .tab button {
-  background-color: inherit;
-  border: none;
-  outline: none;
-  cursor: pointer;
-  padding: 10px 20px;
-  margin-bottom: -1px;
-  width: 150px;
+    background-color: inherit;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    padding: 10px 20px;
+    margin-bottom: -1px;
+    width: 150px;
 
-  /*font-family: LeagueMonoVariable, sans-serif;*/
-  border-radius: 5px 5px 0 0;
-  color: #fff;
+    /*font-family: LeagueMonoVariable, sans-serif;*/
+    border-radius: 5px 5px 0 0;
+    color: #fff;
 }
 
 .tab button:hover:not(.active) {
-  background-color: #2d3230;
+    background-color: #2d3230;
 }
 
 .tab button.active {
-  border: 1px solid #59b1b6;
-  border-bottom: 1px solid #252927;
+    border: 1px solid #59b1b6;
+    border-bottom: 1px solid #252927;
 
-
-  text-shadow:
-      0 0 3px #59b1b6,
-      0 0 5px #59b1b6;
+    text-shadow: 0 0 3px #59b1b6, 0 0 5px #59b1b6;
 }
 
 .tabs-details {
-  border: 1px solid #59b1b6;
-  border-top: 0;
-  padding: 0;
-  margin: 0;
-  overflow: auto;
-  vertical-align: middle;
+    border: 1px solid #59b1b6;
+    border-top: 0;
+    padding: 0;
+    margin: 0;
+    overflow: auto;
+    vertical-align: middle;
 }
-
 </style>


### PR DESCRIPTION
Hi everyone. ☺
So excited to contribute to this project. This PR addresses the following in the GoXLR-UI for better assistive technology support:

1. Assigning proper roles to tabs, tablists, and tabpanels in accordance with the ARIA specification.
2. Routing tabindex values as per the ARIA spec, so the active tab will have a tabindex of 0, while the inactive tabs will have a tabindex of -1.
3. Adding `aria-label` to tablists through a new prop called `label` on the `tabs` component. The `label` prop will default to a fallback value if not provided to avoid breaking the user experience.
4. Implementing keyboard navigation commands for all tablists:
   - Up / left arrows: click and set focus to the previous tab. If the current tab is the first one, the actionwill be performed on the last tab in the tablist.
   - right / down arrows: click and set focus to the next tab. If the current tab is the last one, the actionwill be performed on the first tab in the tablist.
   - home / end keys: click and set focus to the first or last tab, respectively.
   - Please note that these navigation keys only work within the tablists.

I apologize if there's a formatting issue. It seems that VSCode auto formatted the files with prettier and changed indentation spaces or something.

Looking forward for your feedback ☺