### PR TITLE
Accessibility Improvements for Section Labels and Headings

### DIFF
--- a/src/components/GoXLR.vue
+++ b/src/components/GoXLR.vue
@@ -1,122 +1,118 @@
 <template>
+    <div id="main">
+        <DeviceSelector v-if="!isDeviceSet()" />
 
-  <div id="main">
-    <DeviceSelector v-if="!isDeviceSet()"/>
+        <template v-if="isDeviceSet()">
+            <div style="display: flex; flex-direction: row; column-gap: 30px">
+                <div>
+                    <FileTabs />
+                </div>
+            </div>
 
-    <template v-if="isDeviceSet()">
-      <div style="display: flex; flex-direction: row; column-gap: 30px">
-        <div>
-          <FileTabs/>
-        </div>
+            <div style="height: 25px; background-color: #3b413f" />
 
-      </div>
-
-      <div style="height: 25px; background-color: #3b413f"/>
-
-      <Tabs>
-        <Tab name="Mic">
-          <Mic/>
-        </Tab>
-        <Tab name="Mixer" selected>
-          <ContentContainer>
-            <Mixer/>
-          </ContentContainer>
-        </Tab>
-        <Tab name="Configuration">
-          <ContentContainer>
-            <CenteredContainer>
-              <Faders/>
-              <Cough/>
-            </CenteredContainer>
-          </ContentContainer>
-        </Tab>
-        <Tab v-if="!isDeviceMini()" name="Effects">
-          <EffectsTab/>
-        </Tab>
-        <Tab v-if="!isDeviceMini()" name="Sampler">
-          <ContentContainer>
-            <SamplerTab/>
-          </ContentContainer>
-        </Tab>
-        <Tab name="Lighting">
-          <LightingTab/>
-        </Tab>
-        <Tab name="Routing">
-          <ContentContainer>
-            <Routing/>
-          </ContentContainer>
-        </Tab>
-        <Tab name="System">
-          <ContentContainer>
-            <SystemComponent/>
-          </ContentContainer>
-        </Tab>
-      </Tabs>
-    </template>
-  </div>
-
+            <Tabs label="Lower Ribbon">
+                <Tab name="Mic">
+                    <Mic />
+                </Tab>
+                <Tab name="Mixer" selected>
+                    <ContentContainer>
+                        <Mixer />
+                    </ContentContainer>
+                </Tab>
+                <Tab name="Configuration">
+                    <ContentContainer>
+                        <CenteredContainer>
+                            <Faders />
+                            <Cough />
+                        </CenteredContainer>
+                    </ContentContainer>
+                </Tab>
+                <Tab v-if="!isDeviceMini()" name="Effects">
+                    <EffectsTab />
+                </Tab>
+                <Tab v-if="!isDeviceMini()" name="Sampler">
+                    <ContentContainer>
+                        <SamplerTab />
+                    </ContentContainer>
+                </Tab>
+                <Tab name="Lighting">
+                    <LightingTab />
+                </Tab>
+                <Tab name="Routing">
+                    <ContentContainer>
+                        <Routing />
+                    </ContentContainer>
+                </Tab>
+                <Tab name="System">
+                    <ContentContainer>
+                        <SystemComponent />
+                    </ContentContainer>
+                </Tab>
+            </Tabs>
+        </template>
+    </div>
 </template>
 
 <script>
-
-import Faders from "./sections/Faders"
+import Faders from "./sections/Faders";
 import Mixer from "./sections/Mixer";
 import Tabs from "@/components/tabs/Tabs";
 import Tab from "@/components/tabs/Tab";
 import Routing from "@/components/sections/Routing";
 import Mic from "@/components/sections/Mic";
 import DeviceSelector from "@/components/sections/DeviceSelector";
-import {store} from "@/store";
+import { store } from "@/store";
 import Cough from "@/components/sections/Cough";
-import {websocket} from "@/util/sockets";
+import { websocket } from "@/util/sockets";
 import SystemComponent from "@/components/sections/System";
 import FileTabs from "@/components/sections/files/FileTabs";
 import EffectsTab from "@/components/sections/EffectsTab";
-import {isDeviceMini} from "@/util/util";
+import { isDeviceMini } from "@/util/util";
 import LightingTab from "@/components/sections/lighting/LightingTab";
 import SamplerTab from "@/components/sections/SamplerTab";
 import ContentContainer from "@/components/containers/ContentContainer.vue";
 import CenteredContainer from "@/components/containers/CenteredContainer.vue";
 
 export default {
-  name: 'GoXLR',
-  components: {
-    CenteredContainer,
-    ContentContainer,
-    SamplerTab,
-    LightingTab,
-    EffectsTab,
-    FileTabs,
-    SystemComponent,
-    Cough,
-    DeviceSelector,
-    Routing,
-    Tab,
-    Tabs,
-    Mixer,
-    Faders,
-    Mic
-  },
-
-  methods: {
-    isDeviceMini,
-
-    isDeviceSet() {
-      return (store.hasActiveDevice() && store.isConnected());
+    name: "GoXLR",
+    components: {
+        CenteredContainer,
+        ContentContainer,
+        SamplerTab,
+        LightingTab,
+        EffectsTab,
+        FileTabs,
+        SystemComponent,
+        Cough,
+        DeviceSelector,
+        Routing,
+        Tab,
+        Tabs,
+        Mixer,
+        Faders,
+        Mic,
     },
-  },
 
-  created() {
-    websocket.get_status().then((data) => {
-      store.replaceData(data);
-    });
-  },
-}
+    methods: {
+        isDeviceMini,
+
+        isDeviceSet() {
+            return store.hasActiveDevice() && store.isConnected();
+        },
+    },
+
+    created() {
+        websocket.get_status().then((data) => {
+            store.replaceData(data);
+        });
+    },
+};
 </script>
 
 <style scoped>
 #main {
-  width: 100%;
-  font-size: 10pt;
+    width: 100%;
+    font-size: 10pt;
 }
 </style>

--- a/src/components/containers/GroupContainer.vue
+++ b/src/components/containers/GroupContainer.vue
@@ -9,7 +9,7 @@ export default {
     },
     role: {
       type: String,
-      default: "group"
+      default: "region"
     }
   },
 

--- a/src/components/containers/GroupContainer.vue
+++ b/src/components/containers/GroupContainer.vue
@@ -3,6 +3,14 @@ export default {
   name: "GroupContainer",
   props: {
     title: String,
+    level: {
+      type: Number,
+      default: 2
+    },
+    role: {
+      type: String,
+      default: "group"
+    }
   },
 
   data() {
@@ -35,9 +43,9 @@ export default {
 </script>
 
 <template>
-  <div class="container">
+  <div class="container" :role="role" :aria-label="title !== '' ? title : null">
     <div style="width: 100%">
-      <div v-if="title !== ''" class="title">
+      <div v-if="title !== ''" class="title" role="heading" :aria-level="level">
         {{ title }}
       </div>
       <div ref="right" class="right">

--- a/src/components/containers/GroupContainer.vue
+++ b/src/components/containers/GroupContainer.vue
@@ -2,6 +2,7 @@
 export default {
   name: "GroupContainer",
   props: {
+    label: String,
     title: String,
     level: {
       type: Number,
@@ -43,7 +44,7 @@ export default {
 </script>
 
 <template>
-  <div class="container" :role="role" :aria-label="title !== '' ? title : null">
+  <div class="container" :role="role" :aria-label="label || title || ''">
     <div style="width: 100%">
       <div v-if="title !== ''" class="title" role="heading" :aria-level="level">
         {{ title }}

--- a/src/components/containers/WidgetContainer.vue
+++ b/src/components/containers/WidgetContainer.vue
@@ -9,7 +9,7 @@ export default {
 
 <template>
     <div class="container">
-        <p class="title">
+        <p class="title" role="heading" aria-level="3">
             <slot name="title">{{ title }}</slot>
         </p>
         <slot></slot>

--- a/src/components/design/modal/AccessibleModal.vue
+++ b/src/components/design/modal/AccessibleModal.vue
@@ -4,7 +4,7 @@
       <div ref="dialog" class="modal-container" role="dialog" aria-modal="true" :aria-labelledby="`${id}_label`"
            :aria-describedby="`${id}_body`" @keyup.esc.prevent="closeModalEsc">
         <div class="modal-header">
-          <div :id="`${id}_label`">
+          <div :id="`${id}_label`" role="heading" aria-level="2">
             <slot name="title"></slot>
           </div>
           <button v-show=show_close ref="close" @click="closeModal()">

--- a/src/components/lists/CheckSelection.vue
+++ b/src/components/lists/CheckSelection.vue
@@ -13,6 +13,7 @@ export default {
   },
 
   props: {
+    title: String,
     group: String,
     options: Array,
   },
@@ -30,25 +31,13 @@ export default {
 </script>
 
 <template>
-  <WidgetContainer role="group">
+  <WidgetContainer role="group" :aria-label="title">
     <VerticalScrollingContainer>
-      <CheckItem
-          v-for="option in options"
-          :key="option.id"
-          :id="option.id"
-          :group="group"
-          :text="option.label"
-          :selected="option.selected"
-          :disabled="option.disabled"
-          @check-changed="change"
-      />
+      <CheckItem v-for="option in options" :key="option.id" :id="option.id" :group="group" :text="option.label"
+        :selected="option.selected" :disabled="option.disabled" @check-changed="change" />
       <slot></slot>
     </VerticalScrollingContainer>
   </WidgetContainer>
 </template>
 
-<style scoped>
-
-
-
-</style>
+<style scoped></style>

--- a/src/components/lists/RadioSelection.vue
+++ b/src/components/lists/RadioSelection.vue
@@ -12,6 +12,7 @@ export default {
 
   props: {
     title: String,
+    label: String,
     group: String,
     options: Array,
     selected: String,
@@ -48,7 +49,7 @@ export default {
       <slot name="title">{{ title }}</slot>
     </template>
     <ScrollingRadioList ref="list" :group="group" :options="options" :selected="selected" :menu="menu" :menu_id="menu_id"
-      @selection-changed="select" @menu-opened="menuOpened" @menu-selected="menuOptionClicked" :title="title">
+      @selection-changed="select" @menu-opened="menuOpened" @menu-selected="menuOptionClicked" :label="label || title">
       <slot>{{}}</slot>
     </ScrollingRadioList>
   </WidgetContainer>

--- a/src/components/lists/RadioSelection.vue
+++ b/src/components/lists/RadioSelection.vue
@@ -47,11 +47,11 @@ export default {
     <template #title>
       <slot name="title">{{ title }}</slot>
     </template>
-    <ScrollingRadioList ref="list" :group="group" :options="options" :selected="selected" :menu="menu"
-                        :menu_id="menu_id" @selection-changed="select" @menu-opened="menuOpened"
-                        @menu-selected="menuOptionClicked"><slot>{{}}</slot></ScrollingRadioList>
+    <ScrollingRadioList ref="list" :group="group" :options="options" :selected="selected" :menu="menu" :menu_id="menu_id"
+      @selection-changed="select" @menu-opened="menuOpened" @menu-selected="menuOptionClicked" :title="title">
+      <slot>{{}}</slot>
+    </ScrollingRadioList>
   </WidgetContainer>
 </template>
 
-<style scoped>
-</style>
+<style scoped></style>

--- a/src/components/lists/ScrollingRadioList.vue
+++ b/src/components/lists/ScrollingRadioList.vue
@@ -9,7 +9,7 @@ export default {
   components: { DropMenu, RadioItem, VerticalScrollingContainer },
 
   props: {
-    title: { type: String, default: "" },
+    label: { type: String, default: "" },
     group: String,
     options: Array,
     selected: String,
@@ -63,7 +63,7 @@ export default {
 </script>
 
 <template>
-  <VerticalScrollingContainer :class="{ height: max_height }" ref="container" role="radiogroup" :aria-label="title">
+  <VerticalScrollingContainer :class="{ height: max_height }" ref="container" role="radiogroup" :aria-label="label">
     <RadioItem v-for="option in options" :key="option.id" :id="getUniqueId(option.id)" :ref="getUniqueId(option.id)"
       :group="group" :text="option.label" :selected="selected === option.id" :disabled="option.disabled"
       @radio-selected="select(option.id)">

--- a/src/components/lists/ScrollingRadioList.vue
+++ b/src/components/lists/ScrollingRadioList.vue
@@ -6,16 +6,17 @@ import DropMenu from "@/components/design/DropMenu.vue";
 export default {
   name: "ScrollingRadioList",
   emits: ['selection-changed', 'menu-opened', 'menu-selected'],
-  components: {DropMenu, RadioItem, VerticalScrollingContainer},
+  components: { DropMenu, RadioItem, VerticalScrollingContainer },
 
   props: {
+    title: { type: String, default: "" },
     group: String,
     options: Array,
     selected: String,
     menu: Array,
     menu_id: String,
 
-    max_height: {type: String, optional: true, default: "inherit"}
+    max_height: { type: String, optional: true, default: "inherit" }
   },
 
   methods: {
@@ -62,36 +63,22 @@ export default {
 </script>
 
 <template>
-  <VerticalScrollingContainer :class="{ height: max_height }" ref="container" role="radiogroup">
-    <RadioItem
-        v-for="option in options"
-        :key="option.id"
-        :id="getUniqueId(option.id)"
-        :ref="getUniqueId(option.id)"
-        :group="group"
-        :text="option.label"
-        :selected="selected === option.id"
-        :disabled="option.disabled"
-        @radio-selected="select(option.id)"
-    >
+  <VerticalScrollingContainer :class="{ height: max_height }" ref="container" role="radiogroup" :aria-label="title">
+    <RadioItem v-for="option in options" :key="option.id" :id="getUniqueId(option.id)" :ref="getUniqueId(option.id)"
+      :group="group" :text="option.label" :selected="selected === option.id" :disabled="option.disabled"
+      @radio-selected="select(option.id)">
       <template v-if="this.menu !== undefined" #right>
-        <button :aria-label="`${option.label} Options`" :id="getButtonId(option.id)"
-                aria-haspopup="menu" :aria-controls="this.menu_id"
-                @click.prevent.stop="menuOpened($event, getButtonId(option.id), option.id)">
-          <font-awesome-icon icon="fa-solid fa-ellipsis-vertical"/>
+        <button :aria-label="`${option.label} Options`" :id="getButtonId(option.id)" aria-haspopup="menu"
+          :aria-controls="this.menu_id" @click.prevent.stop="menuOpened($event, getButtonId(option.id), option.id)">
+          <font-awesome-icon icon="fa-solid fa-ellipsis-vertical" />
         </button>
       </template>
 
     </RadioItem>
     <slot></slot>
   </VerticalScrollingContainer>
-  <DropMenu
-      v-if="this.menu !== undefined"
-      :options="this.menu"
-      ref="contextMenu"
-      @option-clicked="menuOptionClicked"
-      :menu_id="this.menu_id"
-  />
+  <DropMenu v-if="this.menu !== undefined" :options="this.menu" ref="contextMenu" @option-clicked="menuOptionClicked"
+    :menu_id="this.menu_id" />
 </template>
 
 <style scoped>

--- a/src/components/sections/Faders.vue
+++ b/src/components/sections/Faders.vue
@@ -5,7 +5,8 @@
     <RadioSelection title="Source" group="faders_source" :options="source_options" :selected="getActiveSource()"
       @selection-changed="sourceChanged" :label="'Source for ' + getActiveChannelName()" />
     <RadioSelection title="Mute Behaviour" group="faders_mute" :options="getMuteFunctions()"
-      :selected="getActiveMuteFunction()" @selection-changed="muteFunctionChanged" />
+      :selected="getActiveMuteFunction()" @selection-changed="muteFunctionChanged"
+      :label="'Mute Behaviour for ' + getActiveChannelName()" />
   </GroupContainer>
 </template>
 

--- a/src/components/sections/Faders.vue
+++ b/src/components/sections/Faders.vue
@@ -1,17 +1,17 @@
 <template>
   <GroupContainer title="Faders">
     <RadioSelection title="Channel" group="faders_channel" :options="fader_options" :selected="activeChannel"
-                   @selection-changed="channelChanged"/>
+      @selection-changed="channelChanged" />
     <RadioSelection title="Source" group="faders_source" :options="source_options" :selected="getActiveSource()"
-                   @selection-changed="sourceChanged"/>
+      @selection-changed="sourceChanged" :label="'Source for ' + getActiveChannelName()" />
     <RadioSelection title="Mute Behaviour" group="faders_mute" :options="getMuteFunctions()"
-                   :selected="getActiveMuteFunction()" @selection-changed="muteFunctionChanged"/>
+      :selected="getActiveMuteFunction()" @selection-changed="muteFunctionChanged" />
   </GroupContainer>
 </template>
 
 <script>
-import {store} from "@/store";
-import {websocket} from "@/util/sockets";
+import { store } from "@/store";
+import { websocket } from "@/util/sockets";
 import RadioSelection from "@/components/lists/RadioSelection.vue";
 import GroupContainer from "@/components/containers/GroupContainer.vue";
 
@@ -20,7 +20,7 @@ export default {
    * Everything here focuses around the 'Channel' input,
    */
 
-  components: {GroupContainer, RadioSelection},
+  components: { GroupContainer, RadioSelection },
   name: "MicFaders",
 
   data() {
@@ -28,31 +28,31 @@ export default {
       activeChannel: "A",
 
       fader_options: [
-        {id: "A", label: "Channel 1"},
-        {id: "B", label: "Channel 2"},
-        {id: "C", label: "Channel 3"},
-        {id: "D", label: "Channel 4"}
+        { id: "A", label: "Channel 1" },
+        { id: "B", label: "Channel 2" },
+        { id: "C", label: "Channel 3" },
+        { id: "D", label: "Channel 4" }
       ],
 
       source_options: [
-        {id: "Mic", label: "Mic"},
-        {id: "Chat", label: "Voice Chat"},
-        {id: "Music", label: "Music"},
-        {id: "Game", label: "Game"},
-        {id: "Console", label: "Console"},
-        {id: "LineIn", label: "Line In"},
-        {id: "System", label: "System"},
-        {id: "Sample", label: "Sample"},
-        {id: "Headphones", label: "Headphones"},
-        {id: "LineOut", label: "Line Out"}
+        { id: "Mic", label: "Mic" },
+        { id: "Chat", label: "Voice Chat" },
+        { id: "Music", label: "Music" },
+        { id: "Game", label: "Game" },
+        { id: "Console", label: "Console" },
+        { id: "LineIn", label: "Line In" },
+        { id: "System", label: "System" },
+        { id: "Sample", label: "Sample" },
+        { id: "Headphones", label: "Headphones" },
+        { id: "LineOut", label: "Line Out" }
       ],
 
       mute_options: [
-        {id: "All", label: "Mute All"},
-        {id: "ToStream", label: "Mute to Stream"},
-        {id: "ToVoiceChat", label: "Mute to Voice Chat"},
-        {id: "ToPhones", label: "Mute to Phones"},
-        {id: "ToLineOut", label: "Mute to Line Out"},
+        { id: "All", label: "Mute All" },
+        { id: "ToStream", label: "Mute to Stream" },
+        { id: "ToVoiceChat", label: "Mute to Voice Chat" },
+        { id: "ToPhones", label: "Mute to Phones" },
+        { id: "ToLineOut", label: "Mute to Line Out" },
       ]
     }
   },
@@ -138,10 +138,12 @@ export default {
     getMuteFunctions: function () {
       this.updateDisabledMuteFunctions(this.getActiveSource());
       return this.mute_options;
+    },
+    getActiveChannelName: function () {
+      return this.fader_options.find((option) => option.id === this.activeChannel).label;
     }
   },
 }
 </script>
 
-<style scoped>
-</style>
+<style scoped></style>

--- a/src/components/sections/Mixer.vue
+++ b/src/components/sections/Mixer.vue
@@ -4,15 +4,15 @@
       <!-- TODO: Fix this, really.. :D -->
       <div style="color: #fff">
         <div v-for="output in Object.keys(outputDevices)" :key="output"
-             style="display: flex; flex-direction: row; gap: 6px">
-          <div style="width: 120px">{{ output }}</div>
-          <div style="margin-right: 15px">
+             style="display: flex; flex-direction: row; gap: 6px" role="radiogroup" :aria-label="output">
+          <div style="width: 120px" role="heading" aria-level="3">{{ output }}</div>
+          <div style="margin-right: 15px" role="presentation">
             <label for="A">A:</label> <input @change="setDeviceMix" :checked="isOutputA(outputDevices[output])"
-                                             type="radio" id="A" :name="outputDevices[output]"/>
+                                             type="radio" id="A" :name="outputDevices[output]" aria-label="A"/>
           </div>
-          <div>
+          <div role="presentation">
             <label for="B">B:</label> <input @change="setDeviceMix" :checked="!isOutputA(outputDevices[output])"
-                                             type="radio" id="B" :name="outputDevices[output]"/>
+                                             type="radio" id="B" :name="outputDevices[output]" aria-label="B"/>
           </div>
         </div>
       </div>

--- a/src/components/sections/SamplerTab.vue
+++ b/src/components/sections/SamplerTab.vue
@@ -5,19 +5,19 @@
     <RadioSelection title="Button" group="sampler_button" :options="button_options" :selected="activeButton"
       @selection-changed="setActiveButton" :label="'Button for bank ' + activeBank" />
     <RadioSelection title="Function" group="sampler_function" :options="function_options" :selected="getActiveFunction()"
-      @selection-changed="setActiveFunction" :label="'Function for ' + activeButton + ' button in bank ' + activeBank" />
+      @selection-changed="setActiveFunction" :label="`Function for ${activeButton} button in bank ${activeBank}`" />
     <RadioSelection title="Play Order" group="sampler_order" :options="order_options" :selected="getActiveOrder()"
-      @selection-changed="setActiveOrder" :label="'Play Order for ' + activeButton + ' button in bank ' + activeBank" />
+      @selection-changed="setActiveOrder" :label="`Play Order for ${activeButton} button in bank ${activeBank}`" />
   </GroupContainer>
   <GroupContainer title="Sampler">
     <RadioSelection title="Samples" group="sampler_samples" :options="getSampleOptions()" :selected="activeSample"
-      @selection-changed="setActiveSample">
+      @selection-changed="setActiveSample" :label="`Sample for ${activeButton} button in bank ${activeBank}`">
       <ButtonItem id="add_sample" ref="add_sample_button" text="+" label="Add Sample" :centered="true"
         @click="$refs.add_sample_modal.openModal(undefined, $refs.add_sample_button)" />
     </RadioSelection>
 
     <AudioVisualiser :active-bank="activeBank" :active-button="activeButton" :active-sample="parseInt(activeSample)"
-      @deselect-sample="activeSample = '-1'" />
+      @deselect-sample="activeSample = '-1'" :sampleName="getActiveSampleName(activeSample)" />
   </GroupContainer>
 
   <AccessibleModal ref="add_sample_modal" id="add_sample" :show_footer="true"
@@ -190,6 +190,12 @@ export default {
           store.resume();
         });
       })
+    },
+    getActiveSampleName: function (id) {
+      if (id === "-1") {
+        return "";
+      }
+      return store.getActiveDevice().sampler.banks[this.activeBank][this.activeButton].samples[id].name;
     }
   }
 }

--- a/src/components/sections/SamplerTab.vue
+++ b/src/components/sections/SamplerTab.vue
@@ -1,35 +1,46 @@
 <template xmlns:slot="http://www.w3.org/1999/html">
   <GroupContainer title="Bank">
-    <RadioSelection title="Bank" group="sampler_bank" :options="bank_options" :selected="activeBank" @selection-changed="setActiveBank" />
-    <RadioSelection title="Button" group="sampler_button" :options="button_options" :selected="activeButton" @selection-changed="setActiveButton" />
-    <RadioSelection title="Function" group="sampler_function" :options="function_options" :selected="getActiveFunction()" @selection-changed="setActiveFunction" />
-    <RadioSelection title="Play Order" group="sampler_order" :options="order_options" :selected="getActiveOrder()" @selection-changed="setActiveOrder" />
+    <RadioSelection title="Bank" group="sampler_bank" :options="bank_options" :selected="activeBank"
+      @selection-changed="setActiveBank" />
+    <RadioSelection title="Button" group="sampler_button" :options="button_options" :selected="activeButton"
+      @selection-changed="setActiveButton" :label="'Button for bank ' + activeBank" />
+    <RadioSelection title="Function" group="sampler_function" :options="function_options" :selected="getActiveFunction()"
+      @selection-changed="setActiveFunction" :label="'Function for ' + activeButton + ' button in bank ' + activeBank" />
+    <RadioSelection title="Play Order" group="sampler_order" :options="order_options" :selected="getActiveOrder()"
+      @selection-changed="setActiveOrder" :label="'Play Order for ' + activeButton + ' button in bank ' + activeBank" />
   </GroupContainer>
   <GroupContainer title="Sampler">
-    <RadioSelection title="Samples" group="sampler_samples" :options="getSampleOptions()" :selected="activeSample" @selection-changed="setActiveSample">
-      <ButtonItem id="add_sample" ref="add_sample_button" text="+" label="Add Sample" :centered="true" @click="$refs.add_sample_modal.openModal(undefined, $refs.add_sample_button)" />
+    <RadioSelection title="Samples" group="sampler_samples" :options="getSampleOptions()" :selected="activeSample"
+      @selection-changed="setActiveSample">
+      <ButtonItem id="add_sample" ref="add_sample_button" text="+" label="Add Sample" :centered="true"
+        @click="$refs.add_sample_modal.openModal(undefined, $refs.add_sample_button)" />
     </RadioSelection>
 
-    <AudioVisualiser :active-bank="activeBank" :active-button="activeButton" :active-sample="parseInt(activeSample)" @deselect-sample="activeSample = '-1'" />
+    <AudioVisualiser :active-bank="activeBank" :active-button="activeButton" :active-sample="parseInt(activeSample)"
+      @deselect-sample="activeSample = '-1'" />
   </GroupContainer>
 
-  <AccessibleModal ref="add_sample_modal" id="add_sample" :show_footer="true" @modal-close="selectedAddSample = undefined">
+  <AccessibleModal ref="add_sample_modal" id="add_sample" :show_footer="true"
+    @modal-close="selectedAddSample = undefined">
     <template v-slot:title>
       <span>Add Sample</span>
       <button class="openButton" @click="openSamples" aria-label="Open Samples Directory">
         <font-awesome-icon icon="fa-solid fa-folder" />
       </button>
     </template>
-    <ScrollingRadioList v-if="getSampleList().length > 0" max_height="300px" group="sample_list" :options="getSampleList()" :selected="getSelectedAddSample()" @selection-changed="selectAddSample" />
+    <ScrollingRadioList v-if="getSampleList().length > 0" max_height="300px" group="sample_list"
+      :options="getSampleList()" :selected="getSelectedAddSample()" @selection-changed="selectAddSample" />
     <span v-else>
       There are currently no samples in the samples folder. Copy some over so they can be selected here!
     </span>
     <template v-slot:footer>
-      <ModalButton ref="ok" class="modal-default-button" :enabled="selectedAddSample !== undefined" @click="addSample">Add</ModalButton>
+      <ModalButton ref="ok" class="modal-default-button" :enabled="selectedAddSample !== undefined" @click="addSample">Add
+      </ModalButton>
     </template>
   </AccessibleModal>
 
-  <AccessibleModal ref="add_sample_wait" id="add_sample_wait" :show_footer="false" :show_close="false" :prevent_esc="true">
+  <AccessibleModal ref="add_sample_wait" id="add_sample_wait" :show_footer="false" :show_close="false"
+    :prevent_esc="true">
     <template v-slot:title>Please wait, analysing sample.</template>
     <div tabindex="0">Please wait, sample being analysed.<br />
       This process may take a couple of minutes.<br />
@@ -38,7 +49,7 @@
 </template>
 
 <script>
-import {store} from "@/store";
+import { store } from "@/store";
 import AudioVisualiser from "@/components/sections/sampler/AudioVisualiser";
 import RadioSelection from "@/components/lists/RadioSelection.vue";
 import GroupContainer from "@/components/containers/GroupContainer.vue";
@@ -46,7 +57,7 @@ import ButtonItem from "@/components/lists/ButtonItem.vue";
 import AccessibleModal from "@/components/design/modal/AccessibleModal.vue";
 import ScrollingRadioList from "@/components/lists/ScrollingRadioList.vue";
 import ModalButton from "@/components/design/modal/ModalButton.vue";
-import {websocket} from "@/util/sockets";
+import { websocket } from "@/util/sockets";
 
 export default {
   name: "SamplerTab",
@@ -56,7 +67,8 @@ export default {
     AccessibleModal,
     ButtonItem,
     GroupContainer,
-    RadioSelection, AudioVisualiser},
+    RadioSelection, AudioVisualiser
+  },
 
   data() {
     return {
@@ -70,30 +82,30 @@ export default {
       waitModal: false,
 
       bank_options: [
-        {id: "A", label: "A"},
-        {id: "B", label: "B"},
-        {id: "C", label: "C"}
+        { id: "A", label: "A" },
+        { id: "B", label: "B" },
+        { id: "C", label: "C" }
       ],
 
       button_options: [
-        {id: "TopLeft", label: "Top Left"},
-        {id: "TopRight", label: "Top Right"},
-        {id: "BottomLeft", label: "Bottom Left"},
-        {id: "BottomRight", label: "Bottom Right"}
+        { id: "TopLeft", label: "Top Left" },
+        { id: "TopRight", label: "Top Right" },
+        { id: "BottomLeft", label: "Bottom Left" },
+        { id: "BottomRight", label: "Bottom Right" }
       ],
 
       function_options: [
-        {id: "PlayNext", label: "Play-Next"},
-        {id: "PlayStop", label: "Play-Stop"},
-        {id: "PlayFade", label: "Play-Fade"},
-        {id: "StopOnRelease", label: "Stop on Release"},
-        {id: "FadeOnRelease", label: "Fade on Release"},
-        {id: "Loop", label: "Loop"}
+        { id: "PlayNext", label: "Play-Next" },
+        { id: "PlayStop", label: "Play-Stop" },
+        { id: "PlayFade", label: "Play-Fade" },
+        { id: "StopOnRelease", label: "Stop on Release" },
+        { id: "FadeOnRelease", label: "Fade on Release" },
+        { id: "Loop", label: "Loop" }
       ],
 
       order_options: [
-        {id: "Sequential", label: "Sequential"},
-        {id: "Random", label: "Random"}
+        { id: "Sequential", label: "Sequential" },
+        { id: "Random", label: "Random" }
       ]
     }
   },
@@ -104,11 +116,11 @@ export default {
     },
 
     getSampleOptions() {
-       let samples = [];
-       this.getSamples().forEach((sample, index) => {
-         samples.push({id: index.toString(), label: sample.name});
-       });
-       return samples;
+      let samples = [];
+      this.getSamples().forEach((sample, index) => {
+        samples.push({ id: index.toString(), label: sample.name });
+      });
+      return samples;
     },
 
     setActiveBank(bank) {
@@ -126,13 +138,13 @@ export default {
       return store.getActiveDevice().sampler.banks[this.activeBank][this.activeButton].function;
     },
     setActiveFunction(sampleFunction) {
-      websocket.send_command(store.getActiveSerial(), {"SetSamplerFunction": [this.activeBank, this.activeButton, sampleFunction]});
+      websocket.send_command(store.getActiveSerial(), { "SetSamplerFunction": [this.activeBank, this.activeButton, sampleFunction] });
     },
     getActiveOrder() {
       return store.getActiveDevice().sampler.banks[this.activeBank][this.activeButton].order;
     },
     setActiveOrder(sampleOrder) {
-      websocket.send_command(store.getActiveSerial(), {"SetSamplerOrder": [this.activeBank, this.activeButton, sampleOrder]});
+      websocket.send_command(store.getActiveSerial(), { "SetSamplerOrder": [this.activeBank, this.activeButton, sampleOrder] });
     },
 
     getSamples() {
@@ -173,7 +185,7 @@ export default {
       store.pause();
 
       this.$nextTick(() => {
-        websocket.send_command(store.getActiveSerial(), {"AddSample": [this.activeBank, this.activeButton, name]}).then(() => {
+        websocket.send_command(store.getActiveSerial(), { "AddSample": [this.activeBank, this.activeButton, name] }).then(() => {
           this.$refs.add_sample_wait.closeModal();
           store.resume();
         });
@@ -201,5 +213,4 @@ button {
   color: #fff;
   cursor: pointer;
 }
-
 </style>

--- a/src/components/sections/files/FileTabs.vue
+++ b/src/components/sections/files/FileTabs.vue
@@ -1,15 +1,15 @@
 <template>
-  <Tabs style="width: 480px">
-    <Tab name="Profiles" :selected="true">
-      <ProfileHandler/>
-    </Tab>
-    <Tab v-if="!isDeviceMini()" name="Samples">
-      <SampleHandler/>
-    </Tab>
-    <Tab v-if="!isDeviceMini()" name="Presets">
-      <PresetHandler/>
-    </Tab>
-  </Tabs>
+    <Tabs style="width: 480px" label="Upper Ribbon">
+        <Tab name="Profiles" :selected="true">
+            <ProfileHandler />
+        </Tab>
+        <Tab v-if="!isDeviceMini()" name="Samples">
+            <SampleHandler />
+        </Tab>
+        <Tab v-if="!isDeviceMini()" name="Presets">
+            <PresetHandler />
+        </Tab>
+    </Tabs>
 </template>
 
 <script>
@@ -18,17 +18,15 @@ import Tab from "@/components/tabs/Tab";
 import ProfileHandler from "@/components/profiles/handlers/ProfileHandler";
 import PresetHandler from "@/components/sections/files/PresetHandler";
 import SampleHandler from "@/components/sections/files/SampleHandler";
-import {isDeviceMini} from "@/util/util";
+import { isDeviceMini } from "@/util/util";
 
 export default {
-  name: "FileTabs",
-  methods: {
-    isDeviceMini
-  },
-  components: {SampleHandler, PresetHandler, ProfileHandler, Tabs, Tab},
-}
+    name: "FileTabs",
+    methods: {
+        isDeviceMini,
+    },
+    components: { SampleHandler, PresetHandler, ProfileHandler, Tabs, Tab },
+};
 </script>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/src/components/sections/lighting/LightingTab.vue
+++ b/src/components/sections/lighting/LightingTab.vue
@@ -28,23 +28,45 @@ export default {
   methods: {
     getTabs() {
       return isDeviceMini() ? ['Mixer', 'Cough', 'Global'] : ['Mixer', 'Effects', 'Sampler', 'Cough', 'Global']
+    },
+    onTabKeydown(event) {
+      const tabs = this.getTabs();
+      const activeTab = this.currentTab;
+      const activeTabIndex = tabs.indexOf(activeTab);
+      let nextTab;
+
+      if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+        nextTab = tabs[(activeTabIndex + 1) % tabs.length];
+        //explanation: if activeTabIndex is 0, then 0+1 % 3 = 1, so nextTab is tabs[1]
+      } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+        nextTab =
+          tabs[(activeTabIndex - 1 + tabs.length) % tabs.length];
+        //explanation: if activeTabIndex is 0, then 0-1+3 % 3 = 2, so nextTab is tabs[2]
+      } else if (event.key === "Home") {
+        nextTab = tabs[0];
+      } else if (event.key === "End") {
+        nextTab = tabs[tabs.length - 1];
+      }
+
+      if (nextTab) {
+        this.currentTab = nextTab;
+        //we need a ref on the button element to focus it
+        this.$refs[nextTab][0].focus();
+      }
     }
   }
 }
 </script>
 
 <template>
-  <CenteredContainer>
-    <button
-      v-for="tab in getTabs()"
-      :key="tab"
-      :class="['button', { active: currentTab === tab }]"
-      @click="currentTab = tab"
-    >
+  <CenteredContainer role="tablist" aria-label="Lighting Settings">
+    <button v-for="tab in getTabs()" :key="tab" :class="['button', { active: currentTab === tab }]"
+      @click="currentTab = tab" role="tab" :aria-selected="currentTab === tab" :aria-controls="tab.toLowerCase()"
+      :tabindex="currentTab === tab ? 0 : -1" :ref="tab" @keydown="onTabKeydown">
       {{ tab }}
     </button>
   </CenteredContainer>
-  <component :is="currentTab" />
+  <component :is="currentTab" role="tabpanel" :aria-label="currentTab" />
 </template>
 
 <style scoped>

--- a/src/components/sections/lighting/elements/ColourPicker.vue
+++ b/src/components/sections/lighting/elements/ColourPicker.vue
@@ -100,14 +100,15 @@ export default {
   <WidgetContainer :title="title">
     <slot>
       <div class="spacer"></div>
-      <img src="wheel.png" draggable="false" @mousemove.stop="mouseMove" @mouseleave="mouseLeave" @click="mouseClick" />
+      <img src="wheel.png" draggable="false" @mousemove.stop="mouseMove" @mouseleave="mouseLeave" @click="mouseClick"
+        role="button" tabindex="0" :aria-label="`${title}, Colour Picker`" />
       <div class="spacer"></div>
       <div class="controls">
         <div class="colourPreview"></div>
 
-        <input type="text" :value="hexString" @keyup="updateColour"/>
+        <input type="text" :value="hexString" @keyup="updateColour" :aria-label="title" />
 
-        <button @click="clearColour">
+        <button @click="clearColour" :aria-label="`Clear ${title}`">
           <font-awesome-icon title="Clear" icon="fa-solid fa-xmark" />
         </button>
       </div>
@@ -117,8 +118,8 @@ export default {
 
 <style scoped>
 * {
-    margin: 0;
-    padding: 0;
+  margin: 0;
+  padding: 0;
 }
 
 .spacer {

--- a/src/components/sections/lighting/subTabs/LightingMixer.vue
+++ b/src/components/sections/lighting/subTabs/LightingMixer.vue
@@ -1,8 +1,8 @@
 <script>
-import {store} from "@/store";
-import {websocket} from "@/util/sockets";
-import {LightingInactiveOptions, MuteButtonNamesForFader, ScribbleNames} from "@/util/mixerMapping";
-import {isDeviceMini} from "@/util/util";
+import { store } from "@/store";
+import { websocket } from "@/util/sockets";
+import { LightingInactiveOptions, MuteButtonNamesForFader, ScribbleNames } from "@/util/mixerMapping";
+import { isDeviceMini } from "@/util/util";
 import ContentContainer from "@/components/containers/ContentContainer.vue";
 import GroupContainer from "@/components/containers/GroupContainer.vue";
 import RadioSelection from "@/components/lists/RadioSelection.vue";
@@ -51,11 +51,11 @@ export default {
     isDeviceMini,
 
     /* Channel Selection */
-    selectedChannel: function() {
+    selectedChannel: function () {
       return this.activeChannel;
     },
 
-    onChannelSelectionChange: function(id) {
+    onChannelSelectionChange: function (id) {
       this.activeChannel = id;
 
       if (!isDeviceMini()) {
@@ -67,7 +67,7 @@ export default {
 
     /* Fader Colour Common */
     onFaderColourChange(top, bottom) {
-      websocket.send_command(store.getActiveSerial(), {"SetFaderColours": [this.activeChannel, top, bottom]});
+      websocket.send_command(store.getActiveSerial(), { "SetFaderColours": [this.activeChannel, top, bottom] });
     },
 
     /* Fader Top Colour */
@@ -140,7 +140,7 @@ export default {
         type = "Meter"
       }
 
-      websocket.send_command(store.getActiveSerial(), {"SetFaderDisplayStyle": [this.activeChannel, type]});
+      websocket.send_command(store.getActiveSerial(), { "SetFaderDisplayStyle": [this.activeChannel, type] });
     },
 
     /***************************/
@@ -152,7 +152,7 @@ export default {
 
     onScreenColourChange(value) {
       value = value.substr(1, 6);
-      websocket.send_command(store.getActiveSerial(), {"SetSimpleColour": [ScribbleNames[this.activeChannel], value]});
+      websocket.send_command(store.getActiveSerial(), { "SetSimpleColour": [ScribbleNames[this.activeChannel], value] });
     },
 
     /* Icons */
@@ -183,7 +183,7 @@ export default {
     },
 
     onIconSelectionChange(value) {
-      websocket.send_command(store.getActiveSerial(), {"SetScribbleIcon": [this.activeChannel, value]})
+      websocket.send_command(store.getActiveSerial(), { "SetScribbleIcon": [this.activeChannel, value] })
     },
 
     /* Display Options */
@@ -219,13 +219,13 @@ export default {
     },
 
     setScreenInverted(inverted) {
-      websocket.send_command(store.getActiveSerial(), {"SetScribbleInvert": [this.activeChannel, inverted]});
+      websocket.send_command(store.getActiveSerial(), { "SetScribbleInvert": [this.activeChannel, inverted] });
     },
 
     setScreenNumberShow(show) {
       let channel = Object.keys(store.getActiveDevice().fader_status).indexOf(this.activeChannel) + 1;
       let value = show ? channel.toString() : "";
-      websocket.send_command(store.getActiveSerial(), {"SetScribbleNumber": [this.activeChannel, value]})
+      websocket.send_command(store.getActiveSerial(), { "SetScribbleNumber": [this.activeChannel, value] })
     },
 
     /* Text Field */
@@ -240,7 +240,7 @@ export default {
 
     applyUpdate(event) {
       let value = event.target.value;
-      websocket.send_command(store.getActiveSerial(), {"SetScribbleText": [this.activeChannel, value]})
+      websocket.send_command(store.getActiveSerial(), { "SetScribbleText": [this.activeChannel, value] })
     },
 
 
@@ -268,7 +268,7 @@ export default {
     },
 
     setMuteColourValues(active, inactive) {
-      websocket.send_command(store.getActiveSerial(), {"SetButtonColours": [MuteButtonNamesForFader[this.activeChannel], active, inactive]});
+      websocket.send_command(store.getActiveSerial(), { "SetButtonColours": [MuteButtonNamesForFader[this.activeChannel], active, inactive] });
     },
 
     selectedMuteInactiveOption() {
@@ -276,7 +276,11 @@ export default {
     },
 
     onMuteInactiveSelectionChange(id) {
-      websocket.send_command(store.getActiveSerial(), {"SetButtonOffStyle": [MuteButtonNamesForFader[this.activeChannel], id]});
+      websocket.send_command(store.getActiveSerial(), { "SetButtonOffStyle": [MuteButtonNamesForFader[this.activeChannel], id] });
+    },
+    getSelectedChannelName() {
+      //get the current selected channel name to be used in aria-labels
+      return this.buttonOptions.find(option => option.id === this.activeChannel).label;
     },
   },
 
@@ -292,29 +296,21 @@ export default {
   <div style="display: flex">
     <ContentContainer>
       <GroupContainer title="Faders">
-        <RadioSelection title="Channel"
-          group="lighting_mixer_channel_select"
-          :options="buttonOptions"
-          :selected="selectedChannel()"
-          @selection-changed="onChannelSelectionChange"
-        />
+        <RadioSelection title="Channel" group="lighting_mixer_channel_select" :options="buttonOptions"
+          :selected="selectedChannel()" @selection-changed="onChannelSelectionChange" />
       </GroupContainer>
 
-      <GroupContainer title="Fader">
+      <GroupContainer title="Fader" :label="`Fader Settings for ${getSelectedChannelName()}`">
         <CheckSelection title="Style" :options="getStyleOptions()" @selection-changed="onStyleSelectionChanged" />
-        <ColourPicker title="Bottom Colour" :color-value="getFaderBottomColour()" @colour-changed="onFaderBottomColourChange" />
+        <ColourPicker title="Bottom Colour" :color-value="getFaderBottomColour()"
+          @colour-changed="onFaderBottomColourChange" />
         <ColourPicker title="Top Colour" :color-value="getFaderTopColour()" @colour-changed="onFaderTopColourChange" />
       </GroupContainer>
 
-      <GroupContainer v-if="!isDeviceMini()" title="Screen">
+      <GroupContainer v-if="!isDeviceMini()" title="Screen" :label="`Screen Settings for ${getSelectedChannelName()}`">
         <ColourPicker title="Background Colour" :color-value="getScreenColour()" @colour-changed="onScreenColourChange" />
-        <RadioSelection
-          title="Icon"
-          group="lighting_mixer_icon_select"
-          :options="getIconOptions()"
-          :selected="getSelectedIcon()"
-          @selection-changed="onIconSelectionChange"
-        >
+        <RadioSelection title="Icon" group="lighting_mixer_icon_select" :options="getIconOptions()"
+          :selected="getSelectedIcon()" @selection-changed="onIconSelectionChange">
           <template #title>
             <div>
               <span style="padding-right: 14px">Icons</span>
@@ -328,23 +324,20 @@ export default {
 
         <CheckSelection title="Options" :options="getDisplayOptions()" @selection-changed="onDisplayOptionsChanged">
           <div style="text-align: center">
-            <hr style="margin-top: 14px"/>
+            <hr style="margin-top: 14px" />
             <div style="color: #fff; text-align: left; padding-left: 8px; margin-top: 16px;">Text:</div>
-            <input type="text" v-model="textValue" @blur="applyUpdate" v-on:keyup.enter="applyUpdate"/>
+            <input type="text" v-model="textValue" @blur="applyUpdate" v-on:keyup.enter="applyUpdate" aria-label="Text"
+              aria-description="Text to display on the GoXLR screen" />
           </div>
         </CheckSelection>
       </GroupContainer>
 
-      <GroupContainer title="Mute">
+      <GroupContainer title="Mute" :label="`Mute Settings for ${getSelectedChannelName()}`">
         <ColourPicker title="Active" :color-value="getMuteActiveColour()" @colour-changed="onMuteActiveColourChanged" />
-        <RadioSelection
-            title="Inactive Option"
-            group="lighting_mixer_mute_inactive_behaviour"
-            :options="inactiveOptions"
-            :selected="selectedMuteInactiveOption()"
-            @selection-changed="onMuteInactiveSelectionChange"
-        />
-        <ColourPicker title="Inactive" :color-value="getMuteInactiveColour()" @colour-changed="onMuteInactiveColourChanged" />
+        <RadioSelection title="Inactive Option" group="lighting_mixer_mute_inactive_behaviour" :options="inactiveOptions"
+          :selected="selectedMuteInactiveOption()" @selection-changed="onMuteInactiveSelectionChange" />
+        <ColourPicker title="Inactive" :color-value="getMuteInactiveColour()"
+          @colour-changed="onMuteInactiveColourChanged" />
       </GroupContainer>
     </ContentContainer>
   </div>

--- a/src/components/sections/sampler/AudioVisualiser.vue
+++ b/src/components/sections/sampler/AudioVisualiser.vue
@@ -1,31 +1,39 @@
 <template>
   <WidgetContainer style="width: fit-content">
     <template v-slot:title>Waveform</template>
-    <div class="content">
-      <button class="vertical_button" :aria-label="getPlaybackLabel()" style="text-align: center" v-bind:class="{enabled: (activeSample !== -1)}" @click="playActiveSample()"><font-awesome-icon :icon="getPlaybackButton()"></font-awesome-icon></button>
+    <div class="content" role="group" :aria-label="`Waveform for ${sampleName}`">
+      <button class="vertical_button" :aria-label="getPlaybackLabel()" style="text-align: center"
+        v-bind:class="{ enabled: (activeSample !== -1) }" @click="playActiveSample()"><font-awesome-icon
+          :icon="getPlaybackButton()"></font-awesome-icon></button>
 
       <div ref="wrapper" style="position: relative; width: 500px">
-        <div class="drag_handle left" style="text-align: center" ref="left" v-bind:class="{enabled: (activeSample !== -1)}" @mousedown.stop="mouseDownLeft">|</div>
-        <div class="drag_handle right" ref="right" style="text-align: center" v-bind:class="{enabled: (activeSample !== -1)}" @mousedown.stop="mouseDownRight">|</div>
-        <div style="color: white; height: 170px; line-height: 85px; text-align: center">Waveform Coming Soon!<br/>&lt;-- Position Sliders Supported --&gt;</div>
+        <div class="drag_handle left" style="text-align: center" ref="left"
+          v-bind:class="{ enabled: (activeSample !== -1) }" @mousedown.stop="mouseDownLeft">|</div>
+        <div class="drag_handle right" ref="right" style="text-align: center"
+          v-bind:class="{ enabled: (activeSample !== -1) }" @mousedown.stop="mouseDownRight">|</div>
+        <div style="color: white; height: 170px; line-height: 85px; text-align: center">Waveform Coming Soon!<br />&lt;--
+          Position Sliders Supported --&gt;</div>
       </div>
 
-      <button class="vertical_button" aria-label="Remove Sample" style="text-align: center" v-bind:class="{enabled: (activeSample !== -1)}" @click="deleteActiveSample()"><font-awesome-icon icon="fa-solid fa-trash"></font-awesome-icon></button>
+      <button class="vertical_button" aria-label="Remove Sample" style="text-align: center"
+        v-bind:class="{ enabled: (activeSample !== -1) }" @click="deleteActiveSample()"><font-awesome-icon
+          icon="fa-solid fa-trash"></font-awesome-icon></button>
     </div>
   </WidgetContainer>
 </template>
 
 <script>
-import {websocket} from "@/util/sockets";
-import {store} from "@/store";
+import { websocket } from "@/util/sockets";
+import { store } from "@/store";
 import WidgetContainer from "@/components/containers/WidgetContainer.vue";
 export default {
   name: "AudioVisualiser",
-  components: {WidgetContainer},
+  components: { WidgetContainer },
   props: {
     activeBank: String,
     activeButton: String,
     activeSample: Number,
+    sampleName: String,
   },
 
   data() {
@@ -53,9 +61,9 @@ export default {
       }
 
       if (store.getActiveDevice().sampler.banks[this.activeBank][this.activeButton].is_playing) {
-        websocket.send_command(store.getActiveSerial(), {"StopSamplePlayback": [this.activeBank, this.activeButton]});
+        websocket.send_command(store.getActiveSerial(), { "StopSamplePlayback": [this.activeBank, this.activeButton] });
       } else {
-        websocket.send_command(store.getActiveSerial(), {"PlaySampleByIndex": [this.activeBank, this.activeButton, this.activeSample]});
+        websocket.send_command(store.getActiveSerial(), { "PlaySampleByIndex": [this.activeBank, this.activeButton, this.activeSample] });
       }
     },
 
@@ -78,7 +86,7 @@ export default {
         return;
       }
 
-      websocket.send_command(store.getActiveSerial(), {"RemoveSampleByIndex": [this.activeBank, this.activeButton, this.activeSample]})
+      websocket.send_command(store.getActiveSerial(), { "RemoveSampleByIndex": [this.activeBank, this.activeButton, this.activeSample] })
       this.$emit("deselect-sample");
     },
 
@@ -137,7 +145,7 @@ export default {
         let wrapperWidth = this.$refs.wrapper.clientWidth - this.$refs.left.clientWidth;
         let rightPosition = parseInt(this.rightPosition);
         let percentage = rightPosition / wrapperWidth * 100;
-        websocket.send_command(store.getActiveSerial(), {"SetSampleStopPercent": [this.activeBank, this.activeButton, this.activeSample, percentage]});
+        websocket.send_command(store.getActiveSerial(), { "SetSampleStopPercent": [this.activeBank, this.activeButton, this.activeSample, percentage] });
       }
     },
 

--- a/src/components/sections/system/modals/SettingsButton.vue
+++ b/src/components/sections/system/modals/SettingsButton.vue
@@ -8,34 +8,34 @@
       <div style="padding: 12px">
         <span style="display: inline-block; width: 300px">Mute Button Hold to Mute All Duration: </span>
         <SimpleNumberInput :min-value="0" :max-value="5000" @value-updated="updateHold"
-                           :current-text-value="getHold()"/>
+                           :current-text-value="getHold()" aria-label="Mute Button Hold to Mute All Duration" aria-description="The duration in milliseconds that the mute button must be held to mute all channels"/>
       </div>
       <div v-if="!isDeviceMini()" style="padding: 12px">
         <span style="display: inline-block; width: 300px">Sampler Pre-Record Buffer (Requires Restart): </span>
         <SimpleNumberInput :min-value="0" :max-value="30000" @value-updated="updateSamplerPreRecord"
-                           :current-text-value="getSamplerPreRecord()"/>
+                           :current-text-value="getSamplerPreRecord()" aria-label="Sampler Pre-Record Buffer" aria-description="The duration in milliseconds that the sampler will record before the button is pressed"/>
       </div>
       <div style="padding: 12px">
         <span style="display: inline-block; width: 360px">Allow UI Network Access (Required Restart):</span>
-        <input type="checkbox" :checked="get_allow_network_access()" @change="set_allow_network_access"/>
+        <input type="checkbox" :checked="get_allow_network_access()" @change="set_allow_network_access" aria-label="Allow UI Network Access (Required Restart)" aria-description="Allow the UI to be accessed from other devices on the network"/>
       </div>
       <div style="padding: 12px">
         <span style="display: inline-block; width: 360px">Voice Chat Mute All Also Mutes Mic To Chat Mic:</span>
-        <input type="checkbox" :checked="get_vcmaammtcm()" @change="set_vcmaammtcm"/>
+        <input type="checkbox" :checked="get_vcmaammtcm()" @change="set_vcmaammtcm" aria-label="Voice Chat Mute All Also Mutes Mic To Chat Mic" aria-description="When muting all channels, also mute the mic to chat mic"/>
       </div>
       <div style="padding: 12px">
         <span style="display: inline-block; width: 360px">Autostart on Login:</span>
-        <input type="checkbox" :checked="isAutostart()" @change="setAutoStart"/>
+        <input type="checkbox" :checked="isAutostart()" @change="setAutoStart" aria-label="Autostart on Login" aria-description="Start the GoXLR Utility when the user logs in"/>
       </div>
       <div style="padding: 12px">
         <span style="display: inline-block; width: 360px">Show Tray Icon (requires restart):</span>
-        <input type="checkbox" :checked="isShowIcon()" @change="setShowIcon"/>
+        <input type="checkbox" :checked="isShowIcon()" @change="setShowIcon" aria-label="Show Tray Icon (requires restart)" aria-description="Show the GoXLR Utility icon in the system tray"/>
       </div>
       <div v-if="isTTSAvailable()" style="padding: 12px">
         <span style="display: inline-block; width: 360px">TTS on button press:</span>
-        <input type="checkbox" :checked="isTTSEnabled()" @change="setTTSEnabled"/>
+        <input type="checkbox" :checked="isTTSEnabled()" @change="setTTSEnabled" aria-label="TTS on button press" aria-description="Speak the button status when pressed, either via screen reader or system TTS"/>
       </div>
-      <div style="padding: 12px">
+      <div style="padding: 12px" role="group" aria-label="recover defaults">
         Recover Defaults:<br/>
         <button style="margin: 3px" @click="recover_defaults('Profiles')">Profiles</button>
         <button style="margin: 3px" @click="recover_defaults('MicProfiles')">Mic Profiles</button>

--- a/src/components/sections/system/modals/SettingsButton.vue
+++ b/src/components/sections/system/modals/SettingsButton.vue
@@ -1,42 +1,53 @@
 <template>
-  <BigButton id="settings_button" ref="button" title="Settings" @button-clicked="$refs.modal.openModal(undefined, $refs.button)">
+  <BigButton id="settings_button" ref="button" title="Settings"
+    @button-clicked="$refs.modal.openModal(undefined, $refs.button)">
     <font-awesome-icon icon="fa-solid fa-gear" />
   </BigButton>
   <AccessibleModal width="630px" ref="modal" id="about_modal" :show_footer=false>
     <template v-slot:title>Settings (Work in Progress)</template>
-    <div style="text-align: left">
+    <div style="text-align: left" role=" region" aria-label="settings">
       <div style="padding: 12px">
         <span style="display: inline-block; width: 300px">Mute Button Hold to Mute All Duration: </span>
-        <SimpleNumberInput :min-value="0" :max-value="5000" @value-updated="updateHold"
-                           :current-text-value="getHold()" aria-label="Mute Button Hold to Mute All Duration" aria-description="The duration in milliseconds that the mute button must be held to mute all channels"/>
+        <SimpleNumberInput :min-value="0" :max-value="5000" @value-updated="updateHold" :current-text-value="getHold()"
+          aria-label="Mute Button Hold to Mute All Duration"
+          aria-description="The duration in milliseconds that the mute button must be held to mute all channels" />
       </div>
       <div v-if="!isDeviceMini()" style="padding: 12px">
         <span style="display: inline-block; width: 300px">Sampler Pre-Record Buffer (Requires Restart): </span>
         <SimpleNumberInput :min-value="0" :max-value="30000" @value-updated="updateSamplerPreRecord"
-                           :current-text-value="getSamplerPreRecord()" aria-label="Sampler Pre-Record Buffer" aria-description="The duration in milliseconds that the sampler will record before the button is pressed"/>
+          :current-text-value="getSamplerPreRecord()" aria-label="Sampler Pre-Record Buffer"
+          aria-description="The duration in milliseconds that the sampler will record before the button is pressed" />
       </div>
       <div style="padding: 12px">
         <span style="display: inline-block; width: 360px">Allow UI Network Access (Required Restart):</span>
-        <input type="checkbox" :checked="get_allow_network_access()" @change="set_allow_network_access" aria-label="Allow UI Network Access (Required Restart)" aria-description="Allow the UI to be accessed from other devices on the network"/>
+        <input type="checkbox" :checked="get_allow_network_access()" @change="set_allow_network_access"
+          aria-label="Allow UI Network Access (Required Restart)"
+          aria-description="Allow the UI to be accessed from other devices on the network" />
       </div>
       <div style="padding: 12px">
         <span style="display: inline-block; width: 360px">Voice Chat Mute All Also Mutes Mic To Chat Mic:</span>
-        <input type="checkbox" :checked="get_vcmaammtcm()" @change="set_vcmaammtcm" aria-label="Voice Chat Mute All Also Mutes Mic To Chat Mic" aria-description="When muting all channels, also mute the mic to chat mic"/>
+        <input type="checkbox" :checked="get_vcmaammtcm()" @change="set_vcmaammtcm"
+          aria-label="Voice Chat Mute All Also Mutes Mic To Chat Mic"
+          aria-description="When muting all channels, also mute the mic to chat mic" />
       </div>
       <div style="padding: 12px">
         <span style="display: inline-block; width: 360px">Autostart on Login:</span>
-        <input type="checkbox" :checked="isAutostart()" @change="setAutoStart" aria-label="Autostart on Login" aria-description="Start the GoXLR Utility when the user logs in"/>
+        <input type="checkbox" :checked="isAutostart()" @change="setAutoStart" aria-label="Autostart on Login"
+          aria-description="Start the GoXLR Utility when the user logs in" />
       </div>
       <div style="padding: 12px">
         <span style="display: inline-block; width: 360px">Show Tray Icon (requires restart):</span>
-        <input type="checkbox" :checked="isShowIcon()" @change="setShowIcon" aria-label="Show Tray Icon (requires restart)" aria-description="Show the GoXLR Utility icon in the system tray"/>
+        <input type="checkbox" :checked="isShowIcon()" @change="setShowIcon"
+          aria-label="Show Tray Icon (requires restart)"
+          aria-description="Show the GoXLR Utility icon in the system tray" />
       </div>
       <div v-if="isTTSAvailable()" style="padding: 12px">
         <span style="display: inline-block; width: 360px">TTS on button press:</span>
-        <input type="checkbox" :checked="isTTSEnabled()" @change="setTTSEnabled" aria-label="TTS on button press" aria-description="Speak the button status when pressed, either via screen reader or system TTS"/>
+        <input type="checkbox" :checked="isTTSEnabled()" @change="setTTSEnabled" aria-label="TTS on button press"
+          aria-description="Speak the button status when pressed, either via screen reader or system TTS" />
       </div>
       <div style="padding: 12px" role="group" aria-label="recover defaults">
-        Recover Defaults:<br/>
+        Recover Defaults:<br />
         <button style="margin: 3px" @click="recover_defaults('Profiles')">Profiles</button>
         <button style="margin: 3px" @click="recover_defaults('MicProfiles')">Mic Profiles</button>
         <button style="margin: 3px" @click="recover_defaults('Icons')">Icons</button>
@@ -53,13 +64,13 @@
 import AccessibleModal from "@/components/design/modal/AccessibleModal.vue";
 import BigButton from "@/components/buttons/BigButton.vue";
 import SimpleNumberInput from "@/components/design/SimpleNumberInput.vue";
-import {store} from "@/store";
-import {websocket} from "@/util/sockets";
-import {isDeviceMini} from "@/util/util";
+import { store } from "@/store";
+import { websocket } from "@/util/sockets";
+import { isDeviceMini } from "@/util/util";
 
 export default {
   name: "SettingsButton",
-  components: {SimpleNumberInput, BigButton, AccessibleModal},
+  components: { SimpleNumberInput, BigButton, AccessibleModal },
 
   methods: {
     isDeviceMini,
@@ -68,7 +79,7 @@ export default {
     },
 
     updateHold(value) {
-      websocket.send_command(store.getActiveSerial(), {"SetMuteHoldDuration": value});
+      websocket.send_command(store.getActiveSerial(), { "SetMuteHoldDuration": value });
     },
 
     getSamplerPreRecord() {
@@ -100,7 +111,7 @@ export default {
     },
 
     set_vcmaammtcm(event) {
-      websocket.send_command(store.getActiveSerial(), {"SetVCMuteAlsoMuteCM": event.target.checked})
+      websocket.send_command(store.getActiveSerial(), { "SetVCMuteAlsoMuteCM": event.target.checked })
     },
 
     isAutostart() {
@@ -142,6 +153,4 @@ export default {
 }
 </script>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/src/components/slider/Slider.vue
+++ b/src/components/slider/Slider.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sliderBox">
+  <div class="sliderBox" role="group" :aria-label="title">
     <Label v-bind:title="title" role="heading" aria-level="3" />
     <Range :current-field-value=fieldValue :min-value="getSliderMinValue()" :max-value="getSliderMaxValue()"
            :store-path="storePath" @value-updated="sliderValueUpdated" @mouse-down="setMouseDown"

--- a/src/components/slider/Slider.vue
+++ b/src/components/slider/Slider.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="sliderBox">
-    <Label v-bind:title="title"/>
+    <Label v-bind:title="title" role="heading" aria-level="3" />
     <Range :current-field-value=fieldValue :min-value="getSliderMinValue()" :max-value="getSliderMaxValue()"
            :store-path="storePath" @value-updated="sliderValueUpdated" @mouse-down="setMouseDown"
            @mouse-up="setMouseUp" :background-colour="rangeBackgroundColour" :title="title" :reported-value="getTextValue()"/>

--- a/src/components/slider/SubmixSlider.vue
+++ b/src/components/slider/SubmixSlider.vue
@@ -1,6 +1,6 @@
 <template>
-  <div id="sliderBox">
-    <Label v-bind:title="title" :text-colour="getLabelColour()"/>
+  <div id="sliderBox" role="group" :aria-label="title">
+    <Label v-bind:title="title" :text-colour="getLabelColour()" role="heading" aria-level="3"/>
 
     <div style="display: flex; flex-direction: row">
       <Range id="A" :current-field-value=fieldAValue :min-value="getSliderMinValue()" :max-value="getSliderMaxValue()"

--- a/src/components/slider/components/Input.vue
+++ b/src/components/slider/components/Input.vue
@@ -2,12 +2,12 @@
   <div>
     <div v-if="!editable" class="sliderInput">
       <input type="text" v-on:blur="reset" :value="displayValue()" :min="minValue" :max="maxValue"
-             :disabled="!editable" :aria-description="title" :aria-valuetext="getDisplayValue()" />
+             :disabled="!editable" :aria-label="title" :aria-description="title" :aria-valuetext="getDisplayValue()" />
       <div class="suffix"><span class="filler">{{ displayValue() }}</span><span v-html="getSuffix()"></span></div>
     </div>
     <div v-if="editable" class="sliderInput">
       <input type="number" v-on:input="update" v-on:blur="reset" v-model="localTextValue" :min="minValue"
-             :max="maxValue" :disabled="!editable" :aria-description="title" :aria-valuetext="getDisplayValue()" />
+             :max="maxValue" :disabled="!editable" :aria-label="title" :aria-description="title" :aria-valuetext="getDisplayValue()" />
       <div class="suffix"><span class="filler">{{ localTextValue }}</span><span v-html="getSuffix()"></span></div>
     </div>
   </div>

--- a/src/components/slider/components/Range.vue
+++ b/src/components/slider/components/Range.vue
@@ -4,7 +4,7 @@
       <input class="slider" type="range" v-bind:style="getCurrentStyle" v-bind:min="minValue"
              v-bind:max="maxValue" v-bind:value="localFieldValue" v-on:input="update"
              v-on:mousedown="mouseDown" v-on:mouseup="mouseUp" v-on:keydown="mouseDown" v-on:keyup="mouseUp"
-             :aria-description="title" :aria-valuetext="getReportedValue()"
+             :aria-label="title" :aria-description="title" :aria-valuetext="getReportedValue()"
       />
     </div>
   </div>

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -1,77 +1,131 @@
 <template>
-  <div style="margin-left: 8px; margin-right: 8px">
-    <div class="tab">
-      <button v-for="tab in tabs" :key="tab.name" :class="{ 'active': tab.isActive }" v-show="!tab.hidden" @click="selectTab(tab)">{{tab.name}}</button>
+    <div style="margin-left: 8px; margin-right: 8px">
+        <div class="tab" role="TabList" :aria-label="this.label">
+            <button
+                v-for="tab in tabs"
+                :key="tab.name"
+                :class="{ active: tab.isActive }"
+                v-show="!tab.hidden"
+                @click="selectTab(tab)"
+                role="tab"
+                :aria-selected="tab.isActive"
+                :tabindex="tab.isActive ? 0 : -1"
+                @keydown="onTabKeydown"
+                :ref="tab.name"
+            >
+                {{ tab.name }}
+            </button>
+        </div>
+        <div
+            class="tabs-details"
+            role="tabpanel"
+            :aria-label="getActiveTab().name"
+        >
+            <slot></slot>
+        </div>
     </div>
-    <div class="tabs-details">
-      <slot></slot>
-    </div>
-  </div>
 </template>
 
 <script>
 export default {
-  name: "TabList",
+    name: "TabList",
 
-  data() {
-    return {tabs: []};
-  },
+    data() {
+        return { tabs: [] };
+    },
+    props: {
+        label: {
+            type: String,
+            required: false,
+            default: "Tab list",
+        },
+    },
 
-  created() {
+    created() {},
 
-  },
+    methods: {
+        selectTab(selectedTab) {
+            this.tabs.forEach((tab) => {
+                tab.isActive = tab.name === selectedTab.name;
+            });
+        },
+        getActiveTab() {
+            //return the active tab
+            const activeTab = this.tabs.find((tab) => tab.isActive);
+            if (activeTab) {
+                return activeTab;
+            } else {
+                return "";
+            }
+        },
+        //keyboard navigation
+        onTabKeydown(event) {
+            const tabs = this.tabs;
+            const activeTab = this.getActiveTab();
+            const activeTabIndex = tabs.indexOf(activeTab);
+            let nextTab;
 
-  methods: {
-    selectTab(selectedTab) {
-      this.tabs.forEach(tab => {
-        tab.isActive = (tab.name === selectedTab.name)
-      });
-    }
-  }
-}
+            if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+                nextTab = tabs[(activeTabIndex + 1) % tabs.length];
+                //explanation: if activeTabIndex is 0, then 0+1 % 3 = 1, so nextTab is tabs[1]
+            } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+                nextTab =
+                    tabs[(activeTabIndex - 1 + tabs.length) % tabs.length];
+                //explanation: if activeTabIndex is 0, then 0-1+3 % 3 = 2, so nextTab is tabs[2]
+            } else if (event.key === "Home") {
+                nextTab = tabs[0];
+            } else if (event.key === "End") {
+                nextTab = tabs[tabs.length - 1];
+            }
+
+            if (nextTab) {
+                this.selectTab(nextTab);
+                //nextTab.$el is the button element
+                //we need a ref on the button element to focus it
+                this.$refs[nextTab.name][0].focus();
+            }
+        },
+    },
+};
 </script>
 
 <style>
 .tab {
-  border-bottom: 1px solid #59b1b6;
-  text-align: left;
+    border-bottom: 1px solid #59b1b6;
+    text-align: left;
 }
 
 .tab button {
-  background-color: inherit;
-  border: none;
-  outline: none;
-  cursor: pointer;
-  padding: 10px 20px;
-  margin-bottom: -1px;
-  width: 150px;
+    background-color: inherit;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    padding: 10px 20px;
+    margin-bottom: -1px;
+    width: 150px;
 
-  /*font-family: LeagueMonoVariable, sans-serif;*/
-  border-radius: 5px 5px 0 0;
-  color: #fff;
+    /*font-family: LeagueMonoVariable, sans-serif;*/
+    border-radius: 5px 5px 0 0;
+    color: #fff;
 }
 
 .tab button:hover:not(.active) {
-  background-color: #2d3230;
+    background-color: #2d3230;
 }
 
 .tab button.active {
-  border: 1px solid #59b1b6;
-  border-bottom: 1px solid #252927;
+    border: 1px solid #59b1b6;
+    border-bottom: 1px solid #252927;
 
-
-  text-shadow:
-      0 0 3px #59b1b6,
-      0 0 5px #59b1b6;
+    text-shadow: 0 0 3px #59b1b6, 0 0 5px #59b1b6;
 }
 
 .tabs-details {
-  border: 1px solid #59b1b6;
-  border-top: 0;
-  padding: 0;
-  margin: 0;
-  overflow: auto;
-  vertical-align: middle;
+    border: 1px solid #59b1b6;
+    border-top: 0;
+    padding: 0;
+    margin: 0;
+    overflow: auto;
+    vertical-align: middle;
 }
-
 </style>


### PR DESCRIPTION
Hi everyone! 👋
## Summary:
This Pull Request (PR) introduces numerous enhancements to improve the accessibility of section headings, labels, and additional descriptions for screen reader users. It also includes the changes from PR #15, which has not been merged yet.
## Details:
1. Heading roles have been added to group container titles, dividing the screen into different sections for easier navigation.
2. By default, group containers are marked as regions. A role attribute can be provided to modify this if necessary.
3. A new prop called `label` is introduced to provide ARIA labels for radio groups and checkbox lists. If the prop is not provided, the `title` will be used instead. This allows custom labels for screen reader users that may differ from what is displayed to other users. An example can be seen in point 4.
4. Context-sensitive ARIA labels have been added for inputs that depend on other inputs. For example, in the Configuration tab, changing the fader channel results in an associated device change. The new `label` prop allows us to update the label dynamically to include the selected channel name. This also applies to the Sampler tab, where changing banks or buttons alters the playback order and available samples. The updated label includes the selected bank and button, allowing users to quickly understand the settings they are interacting with and preventing confusion when navigating the interface.
5. The `aria-label` attribute is used to provide labels for all input fields and sliders. The `aria-description` attribute should be used to offer supplementary information when available. Note that some screen readers, such as VoiceOver on iOS and macOS, do not support the `aria-description` attribute.
6. All settings inputs are now accurately labeled for screen reader users.
7. Some `aria-description` attributes have been added to inputs in the settings dialog.
8. Added aria labels to all fields in the Submixing pane, and modifying container roles so screen reader users can receive information about each radio group independently.
9. The technique for tab keyboard navigation (available in PR #15) has been implemented in the lighting tab, which contains five tabs for adjusting lighting settings.

This PR is now ready for review. Thank you for reading, and I'm awaiting your feedback ☺️