### PR TITLE
A11y: provide notifications to sr users via aria-live regions

### DIFF
--- a/src/components/A11yNotifications.vue
+++ b/src/components/A11yNotifications.vue
@@ -1,47 +1,25 @@
 //this component is to show the notifications
 <template>
-    <div class="screenreader-only">
-        <div aria-live="assertive">
-            {{ assertiveNotification }}
-        </div>
-        <div aria-live="polite">
-            {{ politeNotification }}
-        </div>
+  <div class="screenreader-only">
+    <div aria-live="assertive">
+      {{ assertiveNotification }}
     </div>
+    <div aria-live="polite">
+      {{ politeNotification }}
+    </div>
+  </div>
 </template>
 <script>
 import { store } from "@/store";
 export default {
-    name: "A11yNotifications",
-    computed: {
-        assertiveNotification() {
-            return store.getAccessibilityNotification("assertive");
-        },
-        politeNotification() {
-            return store.getAccessibilityNotification("polite");
-        },
+  name: "A11yNotifications",
+  computed: {
+    assertiveNotification() {
+      return store.getAccessibilityNotification("assertive");
     },
+    politeNotification() {
+      return store.getAccessibilityNotification("polite");
+    },
+  },
 };
 </script>
-<style scoped>
-.screenreader-only {
-    position: absolute;
-    left: -10000px;
-    top: auto;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-
-    /**
-    position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-   */
-}
-</style>

--- a/src/components/A11yNotifications.vue
+++ b/src/components/A11yNotifications.vue
@@ -1,0 +1,47 @@
+//this component is to show the notifications
+<template>
+    <div class="screenreader-only">
+        <div aria-live="assertive">
+            {{ assertiveNotification }}
+        </div>
+        <div aria-live="polite">
+            {{ politeNotification }}
+        </div>
+    </div>
+</template>
+<script>
+import { store } from "@/store";
+export default {
+    name: "A11yNotifications",
+    computed: {
+        assertiveNotification() {
+            return store.getAccessibilityNotification("assertive");
+        },
+        politeNotification() {
+            return store.getAccessibilityNotification("polite");
+        },
+    },
+};
+</script>
+<style scoped>
+.screenreader-only {
+    position: absolute;
+    left: -10000px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+
+    /**
+    position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+   */
+}
+</style>

--- a/src/components/GoXLR.vue
+++ b/src/components/GoXLR.vue
@@ -1,62 +1,63 @@
 <template>
-  <div id="main">
-    <DeviceSelector v-if="!isDeviceSet()"/>
+    <div id="main">
+        <DeviceSelector v-if="!isDeviceSet()" />
 
-    <template v-if="isDeviceSet()">
+        <template v-if="isDeviceSet()">
+            <h1 class="screenreader-only">Profiles and Files</h1>
+            <div style="display: flex; flex-direction: row; column-gap: 30px">
+                <div>
+                    <FileTabs />
+                </div>
+            </div>
 
-      <h1 class="screenreader-only">Profiles and Files</h1>
-      <div style="display: flex; flex-direction: row; column-gap: 30px">
-        <div>
-          <FileTabs/>
-        </div>
-      </div>
-
-      <div style="height: 25px; background-color: #3b413f"/>
-      <h1 class="sr-only">Device Settings</h1>
-      <Tabs label="Device Settings">
-        <Tab name="Mic">
-          <Mic/>
-        </Tab>
-        <Tab name="Mixer" selected>
-          <ContentContainer>
-            <Mixer/>
-          </ContentContainer>
-        </Tab>
-        <Tab name="Configuration">
-          <ContentContainer>
-            <CenteredContainer>
-              <Faders/>
-              <Cough/>
-            </CenteredContainer>
-          </ContentContainer>
-        </Tab>
-        <Tab v-if="!isDeviceMini()" name="Effects">
-          <EffectsTab/>
-        </Tab>
-        <Tab v-if="!isDeviceMini()" name="Sampler">
-          <ContentContainer>
-            <SamplerTab/>
-          </ContentContainer>
-        </Tab>
-        <Tab name="Lighting">
-          <LightingTab/>
-        </Tab>
-        <Tab name="Routing">
-          <ContentContainer>
-            <Routing/>
-          </ContentContainer>
-        </Tab>
-        <Tab name="System">
-          <ContentContainer>
-            <SystemComponent/>
-          </ContentContainer>
-        </Tab>
-      </Tabs>
-    </template>
-  </div>
+            <div style="height: 25px; background-color: #3b413f" />
+            <h1 class="sr-only">Device Settings</h1>
+            <Tabs label="Device Settings">
+                <Tab name="Mic">
+                    <Mic />
+                </Tab>
+                <Tab name="Mixer" selected>
+                    <ContentContainer>
+                        <Mixer />
+                    </ContentContainer>
+                </Tab>
+                <Tab name="Configuration">
+                    <ContentContainer>
+                        <CenteredContainer>
+                            <Faders />
+                            <Cough />
+                        </CenteredContainer>
+                    </ContentContainer>
+                </Tab>
+                <Tab v-if="!isDeviceMini()" name="Effects">
+                    <EffectsTab />
+                </Tab>
+                <Tab v-if="!isDeviceMini()" name="Sampler">
+                    <ContentContainer>
+                        <SamplerTab />
+                    </ContentContainer>
+                </Tab>
+                <Tab name="Lighting">
+                    <LightingTab />
+                </Tab>
+                <Tab name="Routing">
+                    <ContentContainer>
+                        <Routing />
+                    </ContentContainer>
+                </Tab>
+                <Tab name="System">
+                    <ContentContainer>
+                        <SystemComponent />
+                    </ContentContainer>
+                </Tab>
+            </Tabs>
+            <A11yNotifications />
+        </template>
+    </div>
 </template>
 
 <script>
+import A11yNotifications from "./A11yNotifications";
 import Faders from "./sections/Faders";
 import Mixer from "./sections/Mixer";
 import Tabs from "@/components/tabs/Tabs";
@@ -64,64 +65,65 @@ import Tab from "@/components/tabs/Tab";
 import Routing from "@/components/sections/Routing";
 import Mic from "@/components/sections/Mic";
 import DeviceSelector from "@/components/sections/DeviceSelector";
-import {store} from "@/store";
+import { store } from "@/store";
 import Cough from "@/components/sections/Cough";
-import {websocket} from "@/util/sockets";
+import { websocket } from "@/util/sockets";
 import SystemComponent from "@/components/sections/System";
 import FileTabs from "@/components/sections/files/FileTabs";
 import EffectsTab from "@/components/sections/EffectsTab";
-import {isDeviceMini} from "@/util/util";
+import { isDeviceMini } from "@/util/util";
 import LightingTab from "@/components/sections/lighting/LightingTab";
 import SamplerTab from "@/components/sections/SamplerTab";
 import ContentContainer from "@/components/containers/ContentContainer.vue";
 import CenteredContainer from "@/components/containers/CenteredContainer.vue";
 
 export default {
-  name: "GoXLR",
-  components: {
-    CenteredContainer,
-    ContentContainer,
-    SamplerTab,
-    LightingTab,
-    EffectsTab,
-    FileTabs,
-    SystemComponent,
-    Cough,
-    DeviceSelector,
-    Routing,
-    Tab,
-    Tabs,
-    Mixer,
-    Faders,
-    Mic,
-  },
-
-  methods: {
-    isDeviceMini,
-
-    isDeviceSet() {
-      return store.hasActiveDevice() && store.isConnected();
+    name: "GoXLR",
+    components: {
+        A11yNotifications,
+        CenteredContainer,
+        ContentContainer,
+        SamplerTab,
+        LightingTab,
+        EffectsTab,
+        FileTabs,
+        SystemComponent,
+        Cough,
+        DeviceSelector,
+        Routing,
+        Tab,
+        Tabs,
+        Mixer,
+        Faders,
+        Mic,
     },
-  },
 
-  created() {
-    websocket.get_status().then((data) => {
-      store.replaceData(data);
-    });
-  },
+    methods: {
+        isDeviceMini,
+
+        isDeviceSet() {
+            return store.hasActiveDevice() && store.isConnected();
+        },
+    },
+
+    created() {
+        websocket.get_status().then((data) => {
+            store.replaceData(data);
+        });
+    },
 };
 </script>
 
 <style>
 .screenreader-only {
-  position: absolute;
-  left: -10000px;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
+    position: absolute;
+    left: -10000px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
 
-  /**
+    /**
     position: absolute;
   width: 1px;
   height: 1px;
@@ -135,7 +137,7 @@ export default {
 }
 
 #main {
-  width: 100%;
-  font-size: 10pt;
+    width: 100%;
+    font-size: 10pt;
 }
 </style>

--- a/src/components/GoXLR.vue
+++ b/src/components/GoXLR.vue
@@ -1,59 +1,59 @@
 <template>
-    <div id="main">
-        <DeviceSelector v-if="!isDeviceSet()" />
+  <div id="main">
+    <DeviceSelector v-if="!isDeviceSet()" />
 
-        <template v-if="isDeviceSet()">
-            <h1 class="screenreader-only">Profiles and Files</h1>
-            <div style="display: flex; flex-direction: row; column-gap: 30px">
-                <div>
-                    <FileTabs />
-                </div>
-            </div>
+    <template v-if="isDeviceSet()">
+      <h1 class="screenreader-only">Profiles and Files</h1>
+      <div style="display: flex; flex-direction: row; column-gap: 30px">
+        <div>
+          <FileTabs />
+        </div>
+      </div>
 
-            <div style="height: 25px; background-color: #3b413f" />
-            <h1 class="sr-only">Device Settings</h1>
-            <Tabs label="Device Settings">
-                <Tab name="Mic">
-                    <Mic />
-                </Tab>
-                <Tab name="Mixer" selected>
-                    <ContentContainer>
-                        <Mixer />
-                    </ContentContainer>
-                </Tab>
-                <Tab name="Configuration">
-                    <ContentContainer>
-                        <CenteredContainer>
-                            <Faders />
-                            <Cough />
-                        </CenteredContainer>
-                    </ContentContainer>
-                </Tab>
-                <Tab v-if="!isDeviceMini()" name="Effects">
-                    <EffectsTab />
-                </Tab>
-                <Tab v-if="!isDeviceMini()" name="Sampler">
-                    <ContentContainer>
-                        <SamplerTab />
-                    </ContentContainer>
-                </Tab>
-                <Tab name="Lighting">
-                    <LightingTab />
-                </Tab>
-                <Tab name="Routing">
-                    <ContentContainer>
-                        <Routing />
-                    </ContentContainer>
-                </Tab>
-                <Tab name="System">
-                    <ContentContainer>
-                        <SystemComponent />
-                    </ContentContainer>
-                </Tab>
-            </Tabs>
-            <A11yNotifications />
-        </template>
-    </div>
+      <div style="height: 25px; background-color: #3b413f" />
+      <h1 class="sr-only">Device Settings</h1>
+      <Tabs label="Device Settings">
+        <Tab name="Mic">
+          <Mic />
+        </Tab>
+        <Tab name="Mixer" selected>
+          <ContentContainer>
+            <Mixer />
+          </ContentContainer>
+        </Tab>
+        <Tab name="Configuration">
+          <ContentContainer>
+            <CenteredContainer>
+              <Faders />
+              <Cough />
+            </CenteredContainer>
+          </ContentContainer>
+        </Tab>
+        <Tab v-if="!isDeviceMini()" name="Effects">
+          <EffectsTab />
+        </Tab>
+        <Tab v-if="!isDeviceMini()" name="Sampler">
+          <ContentContainer>
+            <SamplerTab />
+          </ContentContainer>
+        </Tab>
+        <Tab name="Lighting">
+          <LightingTab />
+        </Tab>
+        <Tab name="Routing">
+          <ContentContainer>
+            <Routing />
+          </ContentContainer>
+        </Tab>
+        <Tab name="System">
+          <ContentContainer>
+            <SystemComponent />
+          </ContentContainer>
+        </Tab>
+      </Tabs>
+    </template>
+    <A11yNotifications />
+  </div>
 </template>
 
 <script>
@@ -78,52 +78,52 @@ import ContentContainer from "@/components/containers/ContentContainer.vue";
 import CenteredContainer from "@/components/containers/CenteredContainer.vue";
 
 export default {
-    name: "GoXLR",
-    components: {
-        A11yNotifications,
-        CenteredContainer,
-        ContentContainer,
-        SamplerTab,
-        LightingTab,
-        EffectsTab,
-        FileTabs,
-        SystemComponent,
-        Cough,
-        DeviceSelector,
-        Routing,
-        Tab,
-        Tabs,
-        Mixer,
-        Faders,
-        Mic,
-    },
+  name: "GoXLR",
+  components: {
+    A11yNotifications,
+    CenteredContainer,
+    ContentContainer,
+    SamplerTab,
+    LightingTab,
+    EffectsTab,
+    FileTabs,
+    SystemComponent,
+    Cough,
+    DeviceSelector,
+    Routing,
+    Tab,
+    Tabs,
+    Mixer,
+    Faders,
+    Mic,
+  },
 
-    methods: {
-        isDeviceMini,
+  methods: {
+    isDeviceMini,
 
-        isDeviceSet() {
-            return store.hasActiveDevice() && store.isConnected();
-        },
+    isDeviceSet() {
+      return store.hasActiveDevice() && store.isConnected();
     },
+  },
 
-    created() {
-        websocket.get_status().then((data) => {
-            store.replaceData(data);
-        });
-    },
+  created() {
+    websocket.get_status().then((data) => {
+      store.replaceData(data);
+    });
+  },
 };
 </script>
 
 <style>
 .screenreader-only {
-    position: absolute;
-    left: -10000px;
-    top: auto;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
 
-    /**
+  /**
     position: absolute;
   width: 1px;
   height: 1px;
@@ -137,7 +137,7 @@ export default {
 }
 
 #main {
-    width: 100%;
-    font-size: 10pt;
+  width: 100%;
+  font-size: 10pt;
 }
 </style>

--- a/src/components/profiles/handlers/ProfileHandler.vue
+++ b/src/components/profiles/handlers/ProfileHandler.vue
@@ -1,64 +1,56 @@
 <template>
-    <div style="height: 30px; text-align: right">
-        <div
-            style="
-                height: 14px;
-                display: inline-block;
-                width: calc(100% - 50px);
-            "
-        >
-            <hr style="border: 1px solid #2d3230" />
-        </div>
-        <button
-            aria-label="Open Profile Directory"
-            class="openButton"
-            @click="openProfiles"
-        >
-            <font-awesome-icon icon="fa-solid fa-folder" />
-        </button>
+  <div style="height: 30px; text-align: right">
+    <div style="height: 14px; display: inline-block; width: calc(100% - 50px)">
+      <hr style="border: 1px solid #2d3230" />
     </div>
-    <div style="height: 290px">
-        <ProfileManager
-            ref="manager"
-            :profile-list="getProfileList()"
-            :active-profile="getActiveProfile()"
-            :menu-list="menuList"
-            @new-profile="newProfile"
-            @load-profile="loadProfile"
-            @save-profile="saveProfile"
-            @save-profile-as="saveProfileAs"
-            @menu-item-pressed="menuItemPressed"
-        />
-    </div>
+    <button
+      aria-label="Open Profile Directory"
+      class="openButton"
+      @click="openProfiles"
+    >
+      <font-awesome-icon icon="fa-solid fa-folder" />
+    </button>
+  </div>
+  <div style="height: 290px">
+    <ProfileManager
+      ref="manager"
+      :profile-list="getProfileList()"
+      :active-profile="getActiveProfile()"
+      :menu-list="menuList"
+      @new-profile="newProfile"
+      @load-profile="loadProfile"
+      @save-profile="saveProfile"
+      @save-profile-as="saveProfileAs"
+      @menu-item-pressed="menuItemPressed"
+    />
+  </div>
 
-    <AccessibleModal ref="deleteModal" id="delProfile">
-        <template v-slot:title>Delete Confirmation</template>
-        <template v-slot:default
-            >Are you sure you want to delete the profile
-            {{ selectedProfile }}?</template
-        >
-        <template v-slot:footer>
-            <ModalButton
-                @click="
-                    $refs.deleteModal.closeModal();
-                    deleteProfile(this.selectedProfile);
-                "
-                >Ok</ModalButton
-            >
-            <ModalButton
-                ref="focusDelDefault"
-                @click="$refs.deleteModal.closeModal()"
-                >Cancel</ModalButton
-            >
-        </template>
-    </AccessibleModal>
+  <AccessibleModal ref="deleteModal" id="delProfile">
+    <template v-slot:title>Delete Confirmation</template>
+    <template v-slot:default
+      >Are you sure you want to delete the profile
+      {{ selectedProfile }}?</template
+    >
+    <template v-slot:footer>
+      <ModalButton
+        @click="
+          $refs.deleteModal.closeModal();
+          deleteProfile(this.selectedProfile);
+        "
+        >Ok</ModalButton
+      >
+      <ModalButton ref="focusDelDefault" @click="$refs.deleteModal.closeModal()"
+        >Cancel</ModalButton
+      >
+    </template>
+  </AccessibleModal>
 
-    <AccessibleModal ref="noDelete" id="delProfile">
-        <template v-slot:title>Unable to Delete</template>
-        <template v-slot:default
-            >It is not possible to delete the current active profile.</template
-        >
-    </AccessibleModal>
+  <AccessibleModal ref="noDelete" id="delProfile">
+    <template v-slot:title>Unable to Delete</template>
+    <template v-slot:default
+      >It is not possible to delete the current active profile.</template
+    >
+  </AccessibleModal>
 </template>
 
 <script>
@@ -69,137 +61,131 @@ import AccessibleModal from "@/components/design/modal/AccessibleModal";
 import ModalButton from "@/components/design/modal/ModalButton";
 
 export default {
-    name: "ProfileHandler",
-    components: { ModalButton, AccessibleModal, ProfileManager },
+  name: "ProfileHandler",
+  components: { ModalButton, AccessibleModal, ProfileManager },
 
-    data() {
-        return {
-            menuList: [
-                { name: "Load Profile", slug: "load" },
-                { name: "Load Colours Only", slug: "colours" },
-                { name: "Delete Profile", slug: "delete" },
-            ],
+  data() {
+    return {
+      menuList: [
+        { name: "Load Profile", slug: "load" },
+        { name: "Load Colours Only", slug: "colours" },
+        { name: "Delete Profile", slug: "delete" },
+      ],
 
-            selectedProfile: "",
-        };
+      selectedProfile: "",
+    };
+  },
+
+  methods: {
+    getProfileList() {
+      return store.getProfileFiles().sort();
     },
 
-    methods: {
-        getProfileList() {
-            return store.getProfileFiles().sort();
-        },
-
-        getActiveProfile() {
-            return store.getActiveDevice().profile_name;
-        },
-
-        menuItemPressed(event) {
-            if (event.option.slug === "colours") {
-                this.loadProfileColours(event.item);
-            }
-
-            if (event.option.slug === "load") {
-                this.loadProfile(event.item);
-            }
-
-            if (event.option.slug === "delete") {
-                if (event.item === this.getActiveProfile()) {
-                    this.$refs.noDelete.openModal(
-                        this.$refs.focusDelDefault,
-                        this.$refs.manager.$refs[
-                            this.$refs.manager.getButtonId(event.item)
-                        ][0]
-                    );
-                } else {
-                    this.selectedProfile = event.item;
-                    this.$refs.deleteModal.openModal(
-                        this.$refs.focusDelDefault,
-                        this.$refs.manager.$refs[
-                            this.$refs.manager.getButtonId(event.item)
-                        ][0]
-                    );
-                }
-            }
-        },
-
-        loadProfile: function (label) {
-            let command = {
-                LoadProfile: [label, false],
-            };
-
-            sendHttpCommand(store.getActiveSerial(), command).catch((error) => {
-                console.log(error);
-            });
-            store.setAccessibilityNotification(
-                "polite",
-                `Profile ${label} Loaded`
-            );
-        },
-
-        loadProfileColours: function (label) {
-            sendHttpCommand(store.getActiveSerial(), {
-                LoadProfileColours: label,
-            });
-            store.setAccessibilityNotification(
-                "polite",
-                `Profile ${label} Colours Loaded`
-            );
-        },
-
-        newProfile(name) {
-            sendHttpCommand(store.getActiveSerial(), { NewProfile: name });
-            store.setAccessibilityNotification(
-                "polite",
-                `Created Profile ${name}`
-            );
-        },
-
-        saveProfile() {
-            console.log("Saving Main Profile..");
-            sendHttpCommand(store.getActiveSerial(), { SaveProfile: [] });
-            store.setAccessibilityNotification("polite", "Profile Saved");
-        },
-
-        saveProfileAs(name) {
-            console.log(name);
-            let command = {
-                SaveProfileAs: name,
-            };
-            sendHttpCommand(store.getActiveSerial(), command);
-            store.setAccessibilityNotification(
-                "polite",
-                `Profile ${name} Saved`
-            );
-        },
-
-        deleteProfile(name) {
-            sendHttpCommand(store.getActiveSerial(), { DeleteProfile: name });
-            store.setAccessibilityNotification(
-                "polite",
-                `Profile ${name} Deleted`
-            );
-        },
-
-        openProfiles() {
-            websocket.open_path("Profiles");
-        },
+    getActiveProfile() {
+      return store.getActiveDevice().profile_name;
     },
+
+    menuItemPressed(event) {
+      if (event.option.slug === "colours") {
+        this.loadProfileColours(event.item);
+      }
+
+      if (event.option.slug === "load") {
+        this.loadProfile(event.item);
+      }
+
+      if (event.option.slug === "delete") {
+        if (event.item === this.getActiveProfile()) {
+          this.$refs.noDelete.openModal(
+            this.$refs.focusDelDefault,
+            this.$refs.manager.$refs[
+              this.$refs.manager.getButtonId(event.item)
+            ][0]
+          );
+        } else {
+          this.selectedProfile = event.item;
+          this.$refs.deleteModal.openModal(
+            this.$refs.focusDelDefault,
+            this.$refs.manager.$refs[
+              this.$refs.manager.getButtonId(event.item)
+            ][0]
+          );
+        }
+      }
+    },
+
+    loadProfile: function (label) {
+      let command = {
+        LoadProfile: [label, false],
+      };
+
+      sendHttpCommand(store.getActiveSerial(), command).catch((error) => {
+        console.log(error);
+      });
+      store.setAccessibilityNotification("polite", `Profile ${label} Loaded`);
+    },
+
+    loadProfileColours: function (label) {
+      sendHttpCommand(store.getActiveSerial(), {
+        LoadProfileColours: label,
+      });
+      store.setAccessibilityNotification(
+        "polite",
+        `Profile ${label} Colours Loaded`
+      );
+    },
+
+    newProfile(name) {
+      sendHttpCommand(store.getActiveSerial(), { NewProfile: name });
+      store.setAccessibilityNotification("polite", `Created Profile ${name}`);
+    },
+
+    saveProfile() {
+      console.log("Saving Main Profile..");
+      sendHttpCommand(store.getActiveSerial(), { SaveProfile: [] });
+      store.setAccessibilityNotification(
+        "polite",
+        `Profile ${this.getActiveProfile()} Saved`
+      );
+    },
+
+    saveProfileAs(name) {
+      console.log(name);
+      let command = {
+        SaveProfileAs: name,
+      };
+      sendHttpCommand(store.getActiveSerial(), command);
+      store.setAccessibilityNotification(
+        "polite",
+        `Profile ${this.getActiveProfile()} Saved as ${name}`
+      );
+    },
+
+    deleteProfile(name) {
+      sendHttpCommand(store.getActiveSerial(), { DeleteProfile: name });
+      store.setAccessibilityNotification("polite", `Profile ${name} Deleted`);
+    },
+
+    openProfiles() {
+      websocket.open_path("Profiles");
+    },
+  },
 };
 </script>
 
 <style scoped>
 .openButton {
-    display: inline-block;
-    color: #a5a7a6;
-    padding: 10px;
-    font-size: 14px;
+  display: inline-block;
+  color: #a5a7a6;
+  padding: 10px;
+  font-size: 14px;
 
-    border: 0;
-    margin: 0;
-    background-color: transparent;
+  border: 0;
+  margin: 0;
+  background-color: transparent;
 }
 
 .openButton:hover {
-    color: #fff;
+  color: #fff;
 }
 </style>

--- a/src/components/profiles/handlers/ProfileHandler.vue
+++ b/src/components/profiles/handlers/ProfileHandler.vue
@@ -1,141 +1,205 @@
 <template>
-  <div style="height: 30px; text-align: right">
-    <div style="height: 14px; display: inline-block; width: calc(100% - 50px);">
-      <hr style="border: 1px solid #2d3230" />
+    <div style="height: 30px; text-align: right">
+        <div
+            style="
+                height: 14px;
+                display: inline-block;
+                width: calc(100% - 50px);
+            "
+        >
+            <hr style="border: 1px solid #2d3230" />
+        </div>
+        <button
+            aria-label="Open Profile Directory"
+            class="openButton"
+            @click="openProfiles"
+        >
+            <font-awesome-icon icon="fa-solid fa-folder" />
+        </button>
     </div>
-    <button aria-label="Open Profile Directory" class="openButton" @click="openProfiles">
-      <font-awesome-icon icon="fa-solid fa-folder" />
-    </button>
-  </div>
-  <div style="height: 290px">
-    <ProfileManager ref="manager" :profile-list="getProfileList()" :active-profile="getActiveProfile()" :menu-list="menuList" @new-profile="newProfile"
-                    @load-profile="loadProfile" @save-profile="saveProfile" @save-profile-as="saveProfileAs" @menu-item-pressed="menuItemPressed" />
-  </div>
+    <div style="height: 290px">
+        <ProfileManager
+            ref="manager"
+            :profile-list="getProfileList()"
+            :active-profile="getActiveProfile()"
+            :menu-list="menuList"
+            @new-profile="newProfile"
+            @load-profile="loadProfile"
+            @save-profile="saveProfile"
+            @save-profile-as="saveProfileAs"
+            @menu-item-pressed="menuItemPressed"
+        />
+    </div>
 
-  <AccessibleModal ref="deleteModal" id="delProfile">
-    <template v-slot:title>Delete Confirmation</template>
-    <template v-slot:default>Are you sure you want to delete the profile {{ selectedProfile }}?</template>
-    <template v-slot:footer>
-      <ModalButton @click="$refs.deleteModal.closeModal(); deleteProfile(this.selectedProfile)">Ok</ModalButton>
-      <ModalButton ref="focusDelDefault" @click="$refs.deleteModal.closeModal()">Cancel</ModalButton>
-    </template>
-  </AccessibleModal>
+    <AccessibleModal ref="deleteModal" id="delProfile">
+        <template v-slot:title>Delete Confirmation</template>
+        <template v-slot:default
+            >Are you sure you want to delete the profile
+            {{ selectedProfile }}?</template
+        >
+        <template v-slot:footer>
+            <ModalButton
+                @click="
+                    $refs.deleteModal.closeModal();
+                    deleteProfile(this.selectedProfile);
+                "
+                >Ok</ModalButton
+            >
+            <ModalButton
+                ref="focusDelDefault"
+                @click="$refs.deleteModal.closeModal()"
+                >Cancel</ModalButton
+            >
+        </template>
+    </AccessibleModal>
 
-  <AccessibleModal ref="noDelete" id="delProfile">
-    <template v-slot:title>Unable to Delete</template>
-    <template v-slot:default>It is not possible to delete the current active profile.</template>
-  </AccessibleModal>
-
+    <AccessibleModal ref="noDelete" id="delProfile">
+        <template v-slot:title>Unable to Delete</template>
+        <template v-slot:default
+            >It is not possible to delete the current active profile.</template
+        >
+    </AccessibleModal>
 </template>
 
 <script>
-import {store} from "@/store";
-import {sendHttpCommand, websocket} from "@/util/sockets";
+import { store } from "@/store";
+import { sendHttpCommand, websocket } from "@/util/sockets";
 import ProfileManager from "@/components/profiles/ProfileManager";
 import AccessibleModal from "@/components/design/modal/AccessibleModal";
 import ModalButton from "@/components/design/modal/ModalButton";
 
 export default {
-  name: "ProfileHandler",
-  components: {ModalButton, AccessibleModal, ProfileManager},
+    name: "ProfileHandler",
+    components: { ModalButton, AccessibleModal, ProfileManager },
 
-  data() {
-    return {
-      menuList: [
-        {name: 'Load Profile', slug: 'load'},
-        {name: 'Load Colours Only', slug: 'colours'},
-        {name: 'Delete Profile', slug: 'delete'}
-      ],
+    data() {
+        return {
+            menuList: [
+                { name: "Load Profile", slug: "load" },
+                { name: "Load Colours Only", slug: "colours" },
+                { name: "Delete Profile", slug: "delete" },
+            ],
 
-      selectedProfile: '',
-    }
-  },
-
-  methods: {
-    getProfileList() {
-      return store.getProfileFiles().sort();
+            selectedProfile: "",
+        };
     },
 
-    getActiveProfile() {
-      return store.getActiveDevice().profile_name;
+    methods: {
+        getProfileList() {
+            return store.getProfileFiles().sort();
+        },
+
+        getActiveProfile() {
+            return store.getActiveDevice().profile_name;
+        },
+
+        menuItemPressed(event) {
+            if (event.option.slug === "colours") {
+                this.loadProfileColours(event.item);
+            }
+
+            if (event.option.slug === "load") {
+                this.loadProfile(event.item);
+            }
+
+            if (event.option.slug === "delete") {
+                if (event.item === this.getActiveProfile()) {
+                    this.$refs.noDelete.openModal(
+                        this.$refs.focusDelDefault,
+                        this.$refs.manager.$refs[
+                            this.$refs.manager.getButtonId(event.item)
+                        ][0]
+                    );
+                } else {
+                    this.selectedProfile = event.item;
+                    this.$refs.deleteModal.openModal(
+                        this.$refs.focusDelDefault,
+                        this.$refs.manager.$refs[
+                            this.$refs.manager.getButtonId(event.item)
+                        ][0]
+                    );
+                }
+            }
+        },
+
+        loadProfile: function (label) {
+            let command = {
+                LoadProfile: [label, false],
+            };
+
+            sendHttpCommand(store.getActiveSerial(), command).catch((error) => {
+                console.log(error);
+            });
+            store.setAccessibilityNotification(
+                "polite",
+                `Profile ${label} Loaded`
+            );
+        },
+
+        loadProfileColours: function (label) {
+            sendHttpCommand(store.getActiveSerial(), {
+                LoadProfileColours: label,
+            });
+            store.setAccessibilityNotification(
+                "polite",
+                `Profile ${label} Colours Loaded`
+            );
+        },
+
+        newProfile(name) {
+            sendHttpCommand(store.getActiveSerial(), { NewProfile: name });
+            store.setAccessibilityNotification(
+                "polite",
+                `Created Profile ${name}`
+            );
+        },
+
+        saveProfile() {
+            console.log("Saving Main Profile..");
+            sendHttpCommand(store.getActiveSerial(), { SaveProfile: [] });
+            store.setAccessibilityNotification("polite", "Profile Saved");
+        },
+
+        saveProfileAs(name) {
+            console.log(name);
+            let command = {
+                SaveProfileAs: name,
+            };
+            sendHttpCommand(store.getActiveSerial(), command);
+            store.setAccessibilityNotification(
+                "polite",
+                `Profile ${name} Saved`
+            );
+        },
+
+        deleteProfile(name) {
+            sendHttpCommand(store.getActiveSerial(), { DeleteProfile: name });
+            store.setAccessibilityNotification(
+                "polite",
+                `Profile ${name} Deleted`
+            );
+        },
+
+        openProfiles() {
+            websocket.open_path("Profiles");
+        },
     },
-
-    menuItemPressed(event) {
-      if (event.option.slug === "colours") {
-        this.loadProfileColours(event.item);
-      }
-
-      if (event.option.slug === "load") {
-        this.loadProfile(event.item);
-      }
-
-      if (event.option.slug === "delete") {
-        if (event.item === this.getActiveProfile()) {
-          this.$refs.noDelete.openModal(this.$refs.focusDelDefault, this.$refs.manager.$refs[this.$refs.manager.getButtonId(event.item)][0]);
-        } else {
-          this.selectedProfile = event.item;
-          this.$refs.deleteModal.openModal(this.$refs.focusDelDefault, this.$refs.manager.$refs[this.$refs.manager.getButtonId(event.item)][0]);
-        }
-      }
-    },
-
-    loadProfile: function (label) {
-      let command = {
-        "LoadProfile": [ label, false ]
-      };
-
-      sendHttpCommand(store.getActiveSerial(), command)
-          .catch((error) => {
-            console.log(error);
-          });
-    },
-
-    loadProfileColours: function(label) {
-      sendHttpCommand(store.getActiveSerial(), { "LoadProfileColours": label });
-    },
-
-    newProfile(name) {
-      sendHttpCommand(store.getActiveSerial(), {"NewProfile": name})
-    },
-
-    saveProfile() {
-      console.log("Saving Main Profile..");
-      sendHttpCommand(store.getActiveSerial(), {"SaveProfile": []});
-    },
-
-    saveProfileAs(name) {
-      console.log(name);
-      let command = {
-        "SaveProfileAs": name
-      }
-      sendHttpCommand(store.getActiveSerial(), command);
-    },
-
-    deleteProfile(name) {
-      sendHttpCommand(store.getActiveSerial(), {"DeleteProfile": name});
-    },
-
-    openProfiles() {
-      websocket.open_path("Profiles");
-    }
-  }
-}
+};
 </script>
 
 <style scoped>
 .openButton {
-  display: inline-block;
-  color: #a5a7a6;
-  padding: 10px;
-  font-size: 14px;
+    display: inline-block;
+    color: #a5a7a6;
+    padding: 10px;
+    font-size: 14px;
 
-  border: 0;
-  margin: 0;
-  background-color: transparent;
+    border: 0;
+    margin: 0;
+    background-color: transparent;
 }
 
 .openButton:hover {
-  color: #fff;
+    color: #fff;
 }
-
 </style>

--- a/src/components/sections/sampler/AudioVisualiser.vue
+++ b/src/components/sections/sampler/AudioVisualiser.vue
@@ -1,33 +1,73 @@
 <template>
   <WidgetContainer style="width: fit-content">
     <template v-slot:title>Waveform</template>
-    <div class="content" role="group" :aria-label="`Waveform for ${sampleName}`">
-      <button class="vertical_button" :aria-label="getPlaybackLabel()" style="text-align: center"
-        @click="playActiveSample()" :disabled="activeSample === -1">
+    <div
+      class="content"
+      role="group"
+      :aria-label="`Waveform for ${sampleName}`"
+    >
+      <button
+        class="vertical_button"
+        :aria-label="getPlaybackLabel()"
+        style="text-align: center"
+        @click="playActiveSample()"
+        :disabled="activeSample === -1"
+      >
         <font-awesome-icon :icon="getPlaybackButton()"></font-awesome-icon>
       </button>
 
-      <div ref="wrapper" style="position: relative; width: 500px; background-color: #252927" role="group"
-        aria-label="Waveform">
+      <div
+        ref="wrapper"
+        style="position: relative; width: 500px; background-color: #252927"
+        role="group"
+        aria-label="Waveform"
+      >
         <div class="cover cover_left"></div>
         <div class="cover cover_right"></div>
-        <div class="drag_handle left" ref="left" v-bind:class="{ enabled: activeSample !== -1 }"
-          @mousedown.stop="mouseDownLeft" @keydown="keyDown" role="slider" aria-label="Sample Start"
-          :aria-disabled="activeSample === -1" tabindex="0" aria-valuemin="0" aria-valuemax="100"
-          :aria-valuenow="+leftPercentage.toFixed(2)" :aria-valuetext="`${+leftPercentage.toFixed(2)}%`">
+        <div
+          class="drag_handle left"
+          ref="left"
+          v-bind:class="{ enabled: activeSample !== -1 }"
+          @mousedown.stop="mouseDownLeft"
+          @keydown="keyDown"
+          role="slider"
+          aria-label="Sample Start"
+          :aria-disabled="activeSample === -1"
+          tabindex="0"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          :aria-valuenow="+leftPercentage.toFixed(2)"
+          :aria-valuetext="`${+leftPercentage.toFixed(2)}%`"
+        >
           |
         </div>
-        <div class="drag_handle right" ref="right" v-bind:class="{ enabled: activeSample !== -1 }" @keydown="keyDown"
-          @mousedown.stop="mouseDownRight" role="slider" aria-label="Sample End" tabindex="0"
-          :aria-disabled="activeSample === -1" aria-valuemin="0" aria-valuemax="100"
-          :aria-valuenow="+rightPercentage.toFixed(2)" :aria-valuetext="`${+rightPercentage.toFixed(2)}%`">
+        <div
+          class="drag_handle right"
+          ref="right"
+          v-bind:class="{ enabled: activeSample !== -1 }"
+          @keydown="keyDown"
+          @mousedown.stop="mouseDownRight"
+          role="slider"
+          aria-label="Sample End"
+          tabindex="0"
+          :aria-disabled="activeSample === -1"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          :aria-valuenow="+rightPercentage.toFixed(2)"
+          :aria-valuetext="`${+rightPercentage.toFixed(2)}%`"
+        >
           |
         </div>
         <div id="waveform" class="waveform"></div>
       </div>
 
-      <button class="vertical_button" aria-label="Remove Sample" style="text-align: center" @click="deleteActiveSample()"
-        :disabled="activeSample === -1">
+      <button
+        class="vertical_button"
+        aria-label="Remove Sample"
+        style="text-align: center"
+        @click="deleteActiveSample()"
+        :disabled="activeSample === -1"
+      >
         <font-awesome-icon icon="fa-solid fa-trash"></font-awesome-icon>
       </button>
     </div>
@@ -235,8 +275,8 @@ export default {
       if (
         position >=
         this.positions.parentWidth -
-        this.positions.elementWidth -
-        this.positions.elementWidth
+          this.positions.elementWidth -
+          this.positions.elementWidth
       ) {
         position =
           this.positions.parentWidth -
@@ -298,7 +338,8 @@ export default {
       let wrapper = this.$refs.wrapper.clientWidth;
 
       // We need to focus on the 'Right' side of the left handle, so pull this down so the max left value is correct (460px)
-      let left_wrapper = wrapper - this.$refs.left.clientWidth - this.$refs.right.clientWidth;
+      let left_wrapper =
+        wrapper - this.$refs.left.clientWidth - this.$refs.right.clientWidth;
       this.leftPercentage = start_pct;
 
       if (this.leftPercentage > 100) {
@@ -324,20 +365,22 @@ export default {
       // The right wrapper value is slightly different, it needs to include the left side, but not the right..
       let right_wrapper = wrapper - this.$refs.right.clientWidth;
 
-      this.rightPosition = Math.round(
-        (stop_pct / 100) * (right_wrapper)
-      );
+      this.rightPosition = Math.round((stop_pct / 100) * right_wrapper);
 
       if (this.rightPercentage > 100) {
         // Something's gone wrong, and a percentage is higher than it should be, Reset.
-        console.log("Something is wrong with the right value max.. Correcting!");
+        console.log(
+          "Something is wrong with the right value max.. Correcting!"
+        );
         this.rightPercentage = 100;
         this.rightPosition = right_wrapper;
         this.mouseUp();
       }
 
       if (this.rightPercentage < 0) {
-        console.log("Something is wrong with the right value min.. Correcting!");
+        console.log(
+          "Something is wrong with the right value min.. Correcting!"
+        );
         this.rightPercentage = 0;
         this.rightPosition = this.$refs.left.clientWidth;
         this.mouseUp();
@@ -444,13 +487,17 @@ export default {
         this.mouseUp();
         return;
       }
-      //shift+pageup/ shift+pagedown, change the step size
+      //pageup/ pagedown, change the step size
       if (event.keyCode === 33) {
         event.preventDefault();
         let index = validSteppers.indexOf(this.stepper);
         if (index > 0) {
           this.stepper = validSteppers[index - 1];
         }
+        store.setAccessibilityNotification(
+          "polite",
+          `Zoom level: ${this.stepper}`
+        );
         return;
       }
       if (event.keyCode === 34) {
@@ -459,6 +506,10 @@ export default {
         if (index < validSteppers.length - 1) {
           this.stepper = validSteppers[index + 1];
         }
+        store.setAccessibilityNotification(
+          "polite",
+          `Zoom level: ${this.stepper}`
+        );
       }
     },
   },

--- a/src/store.js
+++ b/src/store.js
@@ -1,5 +1,5 @@
-import {reactive} from "vue";
-import {applyOperation} from "fast-json-patch";
+import { reactive } from "vue";
+import { applyOperation } from "fast-json-patch";
 
 
 export const store = reactive({
@@ -14,6 +14,13 @@ export const store = reactive({
     status: {
         "mixers": {},
         "files": {}
+    },
+    a11y: {
+        notifications: {
+            enabled: true,
+            assertive: "",
+            polite: ""
+        }
     },
 
     socketDisconnected() {
@@ -162,4 +169,13 @@ export const store = reactive({
     isPaused() {
         return !this.active;
     },
+    getAccessibilityNotification(type) {
+        if (this.a11y.notifications.enabled) {
+            return this.a11y.notifications[type];
+        }
+        return "";
+    },
+    setAccessibilityNotification(type, message) {
+        this.a11y.notifications[type] = message;
+    }
 });


### PR DESCRIPTION
## Summary:

1. Created a new object, called A11y in the store.
2. This object has a notifications object, which has three values:

   - enabled: boolean.
   - assertiveNotification: string
   - politeNotification: string
3. In the store, I created a getter and setter for the notification:

   - the getter receives the notification type as parameter, and returns the notification.
   - the setter receives two parameters: the type, and notification, as strings.

4. I created a component and used it at the botom of the page. This component uses the getter from the store to display the latest notification. It has two divs that have the class .screenreader-only, an assertive notification div, and a polite notification div.
5. Whenever a component wants to display a notification, it calls the store.setAccessibilityNotification(type, notification) method, and the notification would be read automatically ❤️

> ## Note:
> Assertive notifications are highly important notifications that interrupts the screen reader. They should be used for critical > messages only.
> Polite notifications however, are placed in the screen reader queue. So they get read when the screen stops reading the >>> current statement (if any). They should be used for non-critical status updates.

This PR is ready for review. Thanks!