### PR TITLE
Added missing Sampler Pre-Record Buffer Restart Info to Input Aria Label

### DIFF
--- a/src/components/sections/system/modals/SettingsButton.vue
+++ b/src/components/sections/system/modals/SettingsButton.vue
@@ -1,60 +1,128 @@
 <template>
-  <BigButton id="settings_button" ref="button" title="Settings"
-    @button-clicked="$refs.modal.openModal(undefined, $refs.button)">
+  <BigButton
+    id="settings_button"
+    ref="button"
+    title="Settings"
+    @button-clicked="$refs.modal.openModal(undefined, $refs.button)"
+  >
     <font-awesome-icon icon="fa-solid fa-gear" />
   </BigButton>
-  <AccessibleModal width="630px" ref="modal" id="about_modal" :show_footer=false>
+  <AccessibleModal
+    width="630px"
+    ref="modal"
+    id="about_modal"
+    :show_footer="false"
+  >
     <template v-slot:title>Settings (Work in Progress)</template>
     <div style="text-align: left" role=" region" aria-label="settings">
       <div style="padding: 12px">
-        <span style="display: inline-block; width: 300px">Mute Button Hold to Mute All Duration: </span>
-        <SimpleNumberInput :min-value="0" :max-value="5000" @value-updated="updateHold" :current-text-value="getHold()"
+        <span style="display: inline-block; width: 300px"
+          >Mute Button Hold to Mute All Duration:
+        </span>
+        <SimpleNumberInput
+          :min-value="0"
+          :max-value="5000"
+          @value-updated="updateHold"
+          :current-text-value="getHold()"
           aria-label="Mute Button Hold to Mute All Duration"
-          aria-description="The duration in milliseconds that the mute button must be held to mute all channels" />
+          aria-description="The duration in milliseconds that the mute button must be held to mute all channels"
+        />
       </div>
       <div v-if="!isDeviceMini()" style="padding: 12px">
-        <span style="display: inline-block; width: 300px">Sampler Pre-Record Buffer (Requires Restart): </span>
-        <SimpleNumberInput :min-value="0" :max-value="30000" @value-updated="updateSamplerPreRecord"
-          :current-text-value="getSamplerPreRecord()" aria-label="Sampler Pre-Record Buffer"
-          aria-description="The duration in milliseconds that the sampler will record before the button is pressed" />
+        <span style="display: inline-block; width: 300px"
+          >Sampler Pre-Record Buffer (Requires Restart):
+        </span>
+        <SimpleNumberInput
+          :min-value="0"
+          :max-value="30000"
+          @value-updated="updateSamplerPreRecord"
+          :current-text-value="getSamplerPreRecord()"
+          aria-label="Sampler Pre-Record Buffer (Requires Restart)"
+          aria-description="The duration in milliseconds that the sampler will record before the button is pressed"
+        />
       </div>
       <div style="padding: 12px">
-        <span style="display: inline-block; width: 360px">Allow UI Network Access (Required Restart):</span>
-        <input type="checkbox" :checked="get_allow_network_access()" @change="set_allow_network_access"
+        <span style="display: inline-block; width: 360px"
+          >Allow UI Network Access (Required Restart):</span
+        >
+        <input
+          type="checkbox"
+          :checked="get_allow_network_access()"
+          @change="set_allow_network_access"
           aria-label="Allow UI Network Access (Required Restart)"
-          aria-description="Allow the UI to be accessed from other devices on the network" />
+          aria-description="Allow the UI to be accessed from other devices on the network"
+        />
       </div>
       <div style="padding: 12px">
-        <span style="display: inline-block; width: 360px">Voice Chat Mute All Also Mutes Mic To Chat Mic:</span>
-        <input type="checkbox" :checked="get_vcmaammtcm()" @change="set_vcmaammtcm"
+        <span style="display: inline-block; width: 360px"
+          >Voice Chat Mute All Also Mutes Mic To Chat Mic:</span
+        >
+        <input
+          type="checkbox"
+          :checked="get_vcmaammtcm()"
+          @change="set_vcmaammtcm"
           aria-label="Voice Chat Mute All Also Mutes Mic To Chat Mic"
-          aria-description="When muting all channels, also mute the mic to chat mic" />
+          aria-description="When muting all channels, also mute the mic to chat mic"
+        />
       </div>
       <div style="padding: 12px">
-        <span style="display: inline-block; width: 360px">Autostart on Login:</span>
-        <input type="checkbox" :checked="isAutostart()" @change="setAutoStart" aria-label="Autostart on Login"
-          aria-description="Start the GoXLR Utility when the user logs in" />
+        <span style="display: inline-block; width: 360px"
+          >Autostart on Login:</span
+        >
+        <input
+          type="checkbox"
+          :checked="isAutostart()"
+          @change="setAutoStart"
+          aria-label="Autostart on Login"
+          aria-description="Start the GoXLR Utility when the user logs in"
+        />
       </div>
       <div style="padding: 12px">
-        <span style="display: inline-block; width: 360px">Show Tray Icon (requires restart):</span>
-        <input type="checkbox" :checked="isShowIcon()" @change="setShowIcon"
+        <span style="display: inline-block; width: 360px"
+          >Show Tray Icon (requires restart):</span
+        >
+        <input
+          type="checkbox"
+          :checked="isShowIcon()"
+          @change="setShowIcon"
           aria-label="Show Tray Icon (requires restart)"
-          aria-description="Show the GoXLR Utility icon in the system tray" />
+          aria-description="Show the GoXLR Utility icon in the system tray"
+        />
       </div>
       <div v-if="isTTSAvailable()" style="padding: 12px">
-        <span style="display: inline-block; width: 360px">TTS on button press:</span>
-        <input type="checkbox" :checked="isTTSEnabled()" @change="setTTSEnabled" aria-label="TTS on button press"
-          aria-description="Speak the button status when pressed, either via screen reader or system TTS" />
+        <span style="display: inline-block; width: 360px"
+          >TTS on button press:</span
+        >
+        <input
+          type="checkbox"
+          :checked="isTTSEnabled()"
+          @change="setTTSEnabled"
+          aria-label="TTS on button press"
+          aria-description="Speak the button status when pressed, either via screen reader or system TTS"
+        />
       </div>
       <div style="padding: 12px" role="group" aria-label="recover defaults">
         Recover Defaults:<br />
-        <button style="margin: 3px" @click="recover_defaults('Profiles')">Profiles</button>
-        <button style="margin: 3px" @click="recover_defaults('MicProfiles')">Mic Profiles</button>
-        <button style="margin: 3px" @click="recover_defaults('Icons')">Icons</button>
-        <button style="margin: 3px" @click="recover_defaults('Presets')">Presets</button>
+        <button style="margin: 3px" @click="recover_defaults('Profiles')">
+          Profiles
+        </button>
+        <button style="margin: 3px" @click="recover_defaults('MicProfiles')">
+          Mic Profiles
+        </button>
+        <button style="margin: 3px" @click="recover_defaults('Icons')">
+          Icons
+        </button>
+        <button style="margin: 3px" @click="recover_defaults('Presets')">
+          Presets
+        </button>
       </div>
       <div style="padding: 12px">
-        <button style="background-color: darkred; color: white" @click="shutdown_util()">Shutdown GoXLR Utility</button>
+        <button
+          style="background-color: darkred; color: white"
+          @click="shutdown_util()"
+        >
+          Shutdown GoXLR Utility
+        </button>
       </div>
     </div>
   </AccessibleModal>
@@ -79,7 +147,9 @@ export default {
     },
 
     updateHold(value) {
-      websocket.send_command(store.getActiveSerial(), { "SetMuteHoldDuration": value });
+      websocket.send_command(store.getActiveSerial(), {
+        SetMuteHoldDuration: value,
+      });
     },
 
     getSamplerPreRecord() {
@@ -87,7 +157,9 @@ export default {
     },
 
     updateSamplerPreRecord(millis) {
-      websocket.send_command(store.getActiveSerial(), { "SetSamplerPreBufferDuration": millis })
+      websocket.send_command(store.getActiveSerial(), {
+        SetSamplerPreBufferDuration: millis,
+      });
     },
 
     get_allow_network_access() {
@@ -111,7 +183,9 @@ export default {
     },
 
     set_vcmaammtcm(event) {
-      websocket.send_command(store.getActiveSerial(), { "SetVCMuteAlsoMuteCM": event.target.checked })
+      websocket.send_command(store.getActiveSerial(), {
+        SetVCMuteAlsoMuteCM: event.target.checked,
+      });
     },
 
     isAutostart() {
@@ -148,9 +222,9 @@ export default {
 
     shutdown_util() {
       websocket.send_shutdown();
-    }
-  }
-}
+    },
+  },
+};
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
## Summary:
Because we're using aria-labels for the settings modal, and due to the huge number of changes I have done in PR #16, I forgot to add a restart warning to the Sampler Pre-Record Buffer input's aria-label.
This PR fixes that.
> Note: the amount of changes in the commit is caused by the formatter.
Thanks!
