### PR TITLE
A11y: Provide Accessibility Notifications for Sample Addition and Deletion

### DIFF
--- a/src/components/sections/SamplerTab.vue
+++ b/src/components/sections/SamplerTab.vue
@@ -284,7 +284,7 @@ export default {
             store.resume();
             store.setAccessibilityNotification(
               "polite",
-              `sample ${name} added to ${this.activeButton} button in bank ${this.activeBank}.`
+              `Sample ${name} added to ${this.activeButton} button in bank ${this.activeBank}.`
             );
           });
       });

--- a/src/components/sections/SamplerTab.vue
+++ b/src/components/sections/SamplerTab.vue
@@ -1,50 +1,119 @@
 <template>
   <GroupContainer title="Bank">
-    <RadioSelection title="Bank" group="sampler_bank" :options="bank_options" :selected="activeBank"
-      @selection-changed="setActiveBank" />
-    <RadioSelection title="Button" group="sampler_button" :options="button_options" :selected="activeButton"
-      @selection-changed="setActiveButton" :label="'Button for bank ' + activeBank" />
-    <RadioSelection title="Function" group="sampler_function" :options="function_options" :selected="getActiveFunction()"
-      @selection-changed="setActiveFunction" :label="`Function for ${activeButton} button in bank ${activeBank}`" />
-    <RadioSelection title="Play Order" group="sampler_order" :options="order_options" :selected="getActiveOrder()"
-      @selection-changed="setActiveOrder" :label="`Play Order for ${activeButton} button in bank ${activeBank}`" />
+    <RadioSelection
+      title="Bank"
+      group="sampler_bank"
+      :options="bank_options"
+      :selected="activeBank"
+      @selection-changed="setActiveBank"
+    />
+    <RadioSelection
+      title="Button"
+      group="sampler_button"
+      :options="button_options"
+      :selected="activeButton"
+      @selection-changed="setActiveButton"
+      :label="'Button for bank ' + activeBank"
+    />
+    <RadioSelection
+      title="Function"
+      group="sampler_function"
+      :options="function_options"
+      :selected="getActiveFunction()"
+      @selection-changed="setActiveFunction"
+      :label="`Function for ${activeButton} button in bank ${activeBank}`"
+    />
+    <RadioSelection
+      title="Play Order"
+      group="sampler_order"
+      :options="order_options"
+      :selected="getActiveOrder()"
+      @selection-changed="setActiveOrder"
+      :label="`Play Order for ${activeButton} button in bank ${activeBank}`"
+    />
   </GroupContainer>
   <GroupContainer title="Sampler">
-    <RadioSelection title="Samples" group="sampler_samples" :options="getSampleOptions()" :selected="activeSample"
-      @selection-changed="setActiveSample" :label="`Sample for ${activeButton} button in bank ${activeBank}`">
-      <ButtonItem id="add_sample" ref="add_sample_button" text="+" label="Add Sample" :centered="true"
-        @click="$refs.add_sample_modal.openModal(undefined, $refs.add_sample_button)" />
+    <RadioSelection
+      title="Samples"
+      group="sampler_samples"
+      :options="getSampleOptions()"
+      :selected="activeSample"
+      @selection-changed="setActiveSample"
+      :label="`Sample for ${activeButton} button in bank ${activeBank}`"
+    >
+      <ButtonItem
+        id="add_sample"
+        ref="add_sample_button"
+        text="+"
+        label="Add Sample"
+        :centered="true"
+        @click="
+          $refs.add_sample_modal.openModal(undefined, $refs.add_sample_button)
+        "
+      />
     </RadioSelection>
 
-    <AudioVisualiser :active-bank="activeBank" :active-button="activeButton" :active-sample="parseInt(activeSample)"
-      @deselect-sample="activeSample = '-1'" :sample-name="getActiveSampleName(activeSample)" />
+    <AudioVisualiser
+      :active-bank="activeBank"
+      :active-button="activeButton"
+      :active-sample="parseInt(activeSample)"
+      @deselect-sample="activeSample = '-1'"
+      :sample-name="getActiveSampleName(activeSample)"
+    />
   </GroupContainer>
 
-  <AccessibleModal ref="add_sample_modal" id="add_sample" :show_footer="true"
-    @modal-close="selectedAddSample = undefined">
+  <AccessibleModal
+    ref="add_sample_modal"
+    id="add_sample"
+    :show_footer="true"
+    @modal-close="selectedAddSample = undefined"
+  >
     <template v-slot:title>
       <span>Add Sample</span>
-      <button class="openButton" @click="openSamples" aria-label="Open Samples Directory">
+      <button
+        class="openButton"
+        @click="openSamples"
+        aria-label="Open Samples Directory"
+      >
         <font-awesome-icon icon="fa-solid fa-folder" />
       </button>
     </template>
-    <ScrollingRadioList v-if="getSampleList().length > 0" max_height="300px" group="sample_list"
-      :options="getSampleList()" :selected="getSelectedAddSample()" @selection-changed="selectAddSample" />
+    <ScrollingRadioList
+      v-if="getSampleList().length > 0"
+      max_height="300px"
+      group="sample_list"
+      :options="getSampleList()"
+      :selected="getSelectedAddSample()"
+      @selection-changed="selectAddSample"
+    />
     <span v-else>
-      There are currently no samples in the samples folder. Copy some over so they can be selected here!
+      There are currently no samples in the samples folder. Copy some over so
+      they can be selected here!
     </span>
     <template v-slot:footer>
-      <ModalButton ref="ok" class="modal-default-button" :enabled="selectedAddSample !== undefined" @click="addSample">Add
+      <ModalButton
+        ref="ok"
+        class="modal-default-button"
+        :enabled="selectedAddSample !== undefined"
+        @click="addSample"
+        >Add
       </ModalButton>
     </template>
   </AccessibleModal>
 
-  <AccessibleModal ref="add_sample_wait" id="add_sample_wait" :show_footer="false" :show_close="false"
-    :prevent_esc="true">
+  <AccessibleModal
+    ref="add_sample_wait"
+    id="add_sample_wait"
+    :show_footer="false"
+    :show_close="false"
+    :prevent_esc="true"
+  >
     <template v-slot:title>Please wait, analysing sample.</template>
-    <div tabindex="0">Please wait, sample being analysed.<br />
+    <div tabindex="0">
+      Please wait, sample being analysed.<br />
       This process may take a couple of minutes.<br />
-      Your GoXLR <b>WILL</b> be Unresponsive during this time.</div>
+      Your GoXLR <b>WILL</b> be Unresponsive during this time.
+    </div>
   </AccessibleModal>
 </template>
 
@@ -67,7 +136,8 @@ export default {
     AccessibleModal,
     ButtonItem,
     GroupContainer,
-    RadioSelection, AudioVisualiser
+    RadioSelection,
+    AudioVisualiser,
   },
 
   data() {
@@ -84,14 +154,14 @@ export default {
       bank_options: [
         { id: "A", label: "A" },
         { id: "B", label: "B" },
-        { id: "C", label: "C" }
+        { id: "C", label: "C" },
       ],
 
       button_options: [
         { id: "TopLeft", label: "Top Left" },
         { id: "TopRight", label: "Top Right" },
         { id: "BottomLeft", label: "Bottom Left" },
-        { id: "BottomRight", label: "Bottom Right" }
+        { id: "BottomRight", label: "Bottom Right" },
       ],
 
       function_options: [
@@ -100,14 +170,14 @@ export default {
         { id: "PlayFade", label: "Play-Fade" },
         { id: "StopOnRelease", label: "Stop on Release" },
         { id: "FadeOnRelease", label: "Fade on Release" },
-        { id: "Loop", label: "Loop" }
+        { id: "Loop", label: "Loop" },
       ],
 
       order_options: [
         { id: "Sequential", label: "Sequential" },
-        { id: "Random", label: "Random" }
-      ]
-    }
+        { id: "Random", label: "Random" },
+      ],
+    };
   },
 
   methods: {
@@ -133,22 +203,35 @@ export default {
       this.activeSample = "-1";
     },
 
-
     getActiveFunction() {
-      return store.getActiveDevice().sampler.banks[this.activeBank][this.activeButton].function;
+      return store.getActiveDevice().sampler.banks[this.activeBank][
+        this.activeButton
+      ].function;
     },
     setActiveFunction(sampleFunction) {
-      websocket.send_command(store.getActiveSerial(), { "SetSamplerFunction": [this.activeBank, this.activeButton, sampleFunction] });
+      websocket.send_command(store.getActiveSerial(), {
+        SetSamplerFunction: [
+          this.activeBank,
+          this.activeButton,
+          sampleFunction,
+        ],
+      });
     },
     getActiveOrder() {
-      return store.getActiveDevice().sampler.banks[this.activeBank][this.activeButton].order;
+      return store.getActiveDevice().sampler.banks[this.activeBank][
+        this.activeButton
+      ].order;
     },
     setActiveOrder(sampleOrder) {
-      websocket.send_command(store.getActiveSerial(), { "SetSamplerOrder": [this.activeBank, this.activeButton, sampleOrder] });
+      websocket.send_command(store.getActiveSerial(), {
+        SetSamplerOrder: [this.activeBank, this.activeButton, sampleOrder],
+      });
     },
 
     getSamples() {
-      return store.getActiveDevice().sampler.banks[this.activeBank][this.activeButton].samples;
+      return store.getActiveDevice().sampler.banks[this.activeBank][
+        this.activeButton
+      ].samples;
     },
 
     getSampleList() {
@@ -156,7 +239,7 @@ export default {
       for (let sample of Object.keys(store.getSampleFiles()).sort()) {
         samples.push({
           id: sample,
-          label: sample
+          label: sample,
         });
       }
       return samples;
@@ -181,24 +264,41 @@ export default {
       this.$refs.add_sample_modal.returnFocus = undefined;
       this.$refs.add_sample_modal.closeModal();
 
-      this.$refs.add_sample_wait.openModal(undefined, this.$refs.add_sample_button);
+      this.$refs.add_sample_wait.openModal(
+        undefined,
+        this.$refs.add_sample_button
+      );
+      store.setAccessibilityNotification(
+        "polite",
+        "Please wait, analysing sample. This process may take a couple of minutes. Your GoXLR WILL be Unresponsive during this time."
+      );
       store.pause();
 
       this.$nextTick(() => {
-        websocket.send_command(store.getActiveSerial(), { "AddSample": [this.activeBank, this.activeButton, name] }).then(() => {
-          this.$refs.add_sample_wait.closeModal();
-          store.resume();
-        });
-      })
+        websocket
+          .send_command(store.getActiveSerial(), {
+            AddSample: [this.activeBank, this.activeButton, name],
+          })
+          .then(() => {
+            this.$refs.add_sample_wait.closeModal();
+            store.resume();
+            store.setAccessibilityNotification(
+              "polite",
+              `sample ${name} added to ${this.activeButton} button in bank ${this.activeBank}.`
+            );
+          });
+      });
     },
     getActiveSampleName: function (id) {
       if (id === "-1") {
         return "";
       }
-      return store.getActiveDevice().sampler.banks[this.activeBank][this.activeButton].samples[id].name;
+      return store.getActiveDevice().sampler.banks[this.activeBank][
+        this.activeButton
+      ].samples[id].name;
     },
-  }
-}
+  },
+};
 </script>
 
 <style scoped>
@@ -212,7 +312,7 @@ button {
 .openButton {
   display: inline-block;
   color: #a5a7a6;
-  font-size: 14px
+  font-size: 14px;
 }
 
 .openButton:hover {

--- a/src/components/sections/sampler/AudioVisualiser.vue
+++ b/src/components/sections/sampler/AudioVisualiser.vue
@@ -174,7 +174,7 @@ export default {
       });
       store.setAccessibilityNotification(
         "polite",
-        `Sample ${this.sampleName} has been deleted from button ${this.activeButton} in bank ${this.activeBank}`
+        `Sample ${this.sampleName} has been deleted from ${this.activeButton} button in bank ${this.activeBank}`
       );
       this.$emit("deselect-sample");
     },

--- a/src/components/sections/sampler/AudioVisualiser.vue
+++ b/src/components/sections/sampler/AudioVisualiser.vue
@@ -172,6 +172,10 @@ export default {
           this.activeSample,
         ],
       });
+      store.setAccessibilityNotification(
+        "polite",
+        `Sample ${this.sampleName} has been deleted from button ${this.activeButton} in bank ${this.activeBank}`
+      );
       this.$emit("deselect-sample");
     },
 


### PR DESCRIPTION
Greetings all. This PR is to provide accessibility notifications when adding or deleting samples. After some usability tests during the last two days, I thought they would be helpful to Screen Reader Users, to improve their experience in the samples flow.
## Summary:

1. added an accessibility notification when deleting a sample.
2. Added two accessibility notifications for adding samples:
   - When analysing the sample
   - after a successful addition.

Thank you!