### PR TITLE
Update Tabs Shortcut Keys

### DIFF
--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -7,6 +7,7 @@
                 :class="{ active: tab.isActive }"
                 v-show="!tab.hidden"
                 @click="selectTab(tab)"
+                @keydown="onTabKeydown"
                 role="tab"
                 :aria-selected="tab.isActive"
                 :tabindex="tab.isActive ? 0 : -1"
@@ -40,8 +41,8 @@ export default {
         },
     },
 
-    created() {window.addEventListener("keydown",this.onTabKeydown)},
-    unmounted(){window.removeEventListener("keydown",this.onTabKeydown)},
+    created() {window.addEventListener("keydown",this.onTabKeydownGlobal)},
+    unmounted(){window.removeEventListener("keydown",this.onTabKeydownGlobal)},
     methods: {
         selectTab(selectedTab) {
             this.tabs.forEach((tab) => {
@@ -63,8 +64,43 @@ export default {
             const tabs = this.tabs;
             const activeTab = this.getActiveTab();
             const activeTabIndex = tabs.indexOf(activeTab);
+            let nextTab; 
+            switch(event.key){
+                case "ArrowRight":
+                case "ArrowDown":
+                case "PageDown":
+                    nextTab = tabs[(activeTabIndex + 1) % tabs.length];
+                    break;
+                case "ArrowLeft":
+                case "ArrowUp":
+                case "PageUp":
+                    nextTab = tabs[(activeTabIndex - 1 + tabs.length) % tabs.length];
+                    break;
+                case "Home":
+                    nextTab = tabs[0];
+                    break;
+                case "End":
+                    nextTab = tabs[tabs.length-1];
+                    break;
+                default:
+                    break;
+            }
+        
+
+            if (nextTab) {
+                this.selectTab(nextTab);
+                //nextTab.$el is the button element
+                //we need a ref on the button element to focus it
+                this.$refs[nextTab.name][0].focus();
+            }
+        },
+        onTabKeydownGlobal(event) {
+            if(this.label!=="Device Settings")return;
+            const tabs = this.tabs;
+            // const activeTab = this.getActiveTab();
+            // const activeTabIndex = tabs.indexOf(activeTab);
             let nextTab;
-            if(event.shiftKey){
+            if(event.shiftKey && event.ctrlKey){
                 // Shift(Number) have different symbol between US keyboard and Other language. 
                 switch(event.code){
                     case "Digit1":
@@ -76,45 +112,6 @@ export default {
                     case "Digit7":
                     case "Digit8":
                         nextTab = tabs[Number(event.code[5])-1];
-                        break;
-                    default:
-                        break;
-                }
-                switch(event.key){
-                    case "S":
-                    case "D":
-                        nextTab = tabs[(activeTabIndex + 1) % tabs.length];
-                        break;
-                    case "W":
-                    case "A":
-                        nextTab = tabs[(activeTabIndex - 1 + tabs.length) % tabs.length];
-                        break;
-                    case "Q":
-                        nextTab = tabs[0];
-                        break;
-                    case "E":
-                        nextTab = tabs[tabs.length-1];
-                        break;
-                    default:
-                        break;
-                }
-            } else {  
-                switch(event.key){
-                    case "ArrowRight":
-                    case "ArrowDown":
-                    case "PageDown":
-                        nextTab = tabs[(activeTabIndex + 1) % tabs.length];
-                        break;
-                    case "ArrowLeft":
-                    case "ArrowUp":
-                    case "PageUp":
-                        nextTab = tabs[(activeTabIndex - 1 + tabs.length) % tabs.length];
-                        break;
-                    case "Home":
-                        nextTab = tabs[0];
-                        break;
-                    case "End":
-                        nextTab = tabs[tabs.length-1];
                         break;
                     default:
                         break;

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -64,7 +64,6 @@ export default {
             const activeTab = this.getActiveTab();
             const activeTabIndex = tabs.indexOf(activeTab);
             let nextTab;
-            console.log(event);
             if(event.shiftKey){
                 // Shift(Number) have different symbol between US keyboard and Other language. 
                 switch(event.code){

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -59,11 +59,12 @@ export default {
         },
         //keyboard navigation
         onTabKeydown(event) {
+            if(this.label!=="Device Settings")return;
             const tabs = this.tabs;
             const activeTab = this.getActiveTab();
             const activeTabIndex = tabs.indexOf(activeTab);
             let nextTab;
-
+            console.log(event);
             if(event.shiftKey){
                 // Shift(Number) have different symbol between US keyboard and Other language. 
                 switch(event.code){

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -10,7 +10,6 @@
                 role="tab"
                 :aria-selected="tab.isActive"
                 :tabindex="tab.isActive ? 0 : -1"
-                @keydown="onTabKeydown"
                 :ref="tab.name"
             >
                 {{ tab.name }}
@@ -41,8 +40,8 @@ export default {
         },
     },
 
-    created() {},
-
+    created() {window.addEventListener("keydown",this.onTabKeydown)},
+    unmounted(){window.removeEventListener("keydown",this.onTabKeydown)},
     methods: {
         selectTab(selectedTab) {
             this.tabs.forEach((tab) => {
@@ -65,17 +64,61 @@ export default {
             const activeTabIndex = tabs.indexOf(activeTab);
             let nextTab;
 
-            if (event.key === "ArrowRight" || event.key === "ArrowDown") {
-                nextTab = tabs[(activeTabIndex + 1) % tabs.length];
-                //explanation: if activeTabIndex is 0, then 0+1 % 3 = 1, so nextTab is tabs[1]
-            } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
-                nextTab =
-                    tabs[(activeTabIndex - 1 + tabs.length) % tabs.length];
-                //explanation: if activeTabIndex is 0, then 0-1+3 % 3 = 2, so nextTab is tabs[2]
-            } else if (event.key === "Home") {
-                nextTab = tabs[0];
-            } else if (event.key === "End") {
-                nextTab = tabs[tabs.length - 1];
+            if(event.shiftKey){
+                // Shift(Number) have different symbol between US keyboard and Other language. 
+                switch(event.code){
+                    case "Digit1":
+                    case "Digit2":
+                    case "Digit3":
+                    case "Digit4":
+                    case "Digit5":
+                    case "Digit6":
+                    case "Digit7":
+                    case "Digit8":
+                        nextTab = tabs[Number(event.code[5])-1];
+                        break;
+                    default:
+                        break;
+                }
+                switch(event.key){
+                    case "S":
+                    case "D":
+                        nextTab = tabs[(activeTabIndex + 1) % tabs.length];
+                        break;
+                    case "W":
+                    case "A":
+                        nextTab = tabs[(activeTabIndex - 1 + tabs.length) % tabs.length];
+                        break;
+                    case "Q":
+                        nextTab = tabs[0];
+                        break;
+                    case "E":
+                        nextTab = tabs[tabs.length-1];
+                        break;
+                    default:
+                        break;
+                }
+            } else {  
+                switch(event.key){
+                    case "ArrowRight":
+                    case "ArrowDown":
+                    case "PageDown":
+                        nextTab = tabs[(activeTabIndex + 1) % tabs.length];
+                        break;
+                    case "ArrowLeft":
+                    case "ArrowUp":
+                    case "PageUp":
+                        nextTab = tabs[(activeTabIndex - 1 + tabs.length) % tabs.length];
+                        break;
+                    case "Home":
+                        nextTab = tabs[0];
+                        break;
+                    case "End":
+                        nextTab = tabs[tabs.length-1];
+                        break;
+                    default:
+                        break;
+                }
             }
 
             if (nextTab) {

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -7,10 +7,10 @@
                 :class="{ active: tab.isActive }"
                 v-show="!tab.hidden"
                 @click="selectTab(tab)"
-                @keydown="onTabKeydown"
                 role="tab"
                 :aria-selected="tab.isActive"
                 :tabindex="tab.isActive ? 0 : -1"
+                @keydown="onTabKeydown"
                 :ref="tab.name"
             >
                 {{ tab.name }}
@@ -60,7 +60,6 @@ export default {
         },
         //keyboard navigation
         onTabKeydown(event) {
-            if(this.label!=="Device Settings")return;
             const tabs = this.tabs;
             const activeTab = this.getActiveTab();
             const activeTabIndex = tabs.indexOf(activeTab);


### PR DESCRIPTION
## Change Device Settings Tabs shortcut key to work without focusing any tab.

* add window.addEventListener on created()
* add window.removeEventListener on unmounted()
* remove @keydown from button
* work only "Device Settings" Tabs.

## Add shortcut keys to select tab direct by number-key with shift-key.

* ex. Shift + 3 selects "Configuration" Tab.

## Add shortcut keys variation to select tab .

* add PageUp, PageDown. it works same action ArrowUp and ArrowDown.

Exclude the following if you don't like these. it depends on your preference.
or Could you please suggest another way?

* add Shift+WASD. it works same action Arrow keys.
* add Shift+QE. it works same action Home and End. 