### PR TITLE
Update the Visualiser to use 'Raw' Encoder Values (Util #d6ecd993)

### DIFF
--- a/src/components/visualisation/GoXLRVisualiser.vue
+++ b/src/components/visualisation/GoXLRVisualiser.vue
@@ -181,7 +181,7 @@ export default {
         return `rotate(0deg)`;
       }
 
-      const effectAmount = store.getActiveDevice().effects.current[effectName].raw_encoder,
+      const effectAmount = store.getActiveDevice().effects.current[effectName].amount,
           hardTuneActive = store.getActiveDevice().effects.current.hard_tune.is_enabled,
           transformRotationLimit = 270;
 

--- a/src/components/visualisation/GoXLRVisualiser.vue
+++ b/src/components/visualisation/GoXLRVisualiser.vue
@@ -181,7 +181,7 @@ export default {
         return `rotate(0deg)`;
       }
 
-      const effectAmount = store.getActiveDevice().effects.current[effectName].amount,
+      const effectAmount = store.getActiveDevice().effects.current[effectName].raw_encoder,
           hardTuneActive = store.getActiveDevice().effects.current.hard_tune.is_enabled,
           transformRotationLimit = 270;
 
@@ -209,41 +209,28 @@ export default {
 
       return `#${store.getActiveDevice().lighting.encoders[effectName].colour_three}`;
     },
-    computeEncoderLevelColour(effectEncoderName, effectLightingName, indicatorLevel, centerMode = false, affectedByHardTune = false) {
+    computeEncoderLevelColour(effectEncoderName, effectLightingName, indicatorLevel, centerMode = false) {
       if (isDeviceMini()) {
         return "#000";
       }
 
       const colours = store.getActiveDevice().lighting.encoders[effectLightingName],
-        effectAmount = store.getActiveDevice().effects.current[effectEncoderName].amount,
-        hardTuneActive = store.getActiveDevice().effects.current.hard_tune.is_enabled,
+        effectAmount = store.getActiveDevice().effects.current[effectEncoderName].raw_encoder,
         maxLevel = 12;  // the goxlr only has 12 levels as the first one is always on
 
       // set the maximum effect range
-      let effectLevelRange = (centerMode ? 50 : 100);
+      let effectLevelRange = (centerMode ? 48 : 24);
 
-      // the gender encoder requires special treatment
-      if (effectEncoderName === "gender") {
-        const encoderStyle = store.getActiveDevice().effects.current[effectEncoderName].style
-
-        switch (encoderStyle) {
-          case "Narrow":
-            effectLevelRange = 25; // range from -12 to +12 = 24
-            break;
-
-          case "Medium":
-            effectLevelRange = 51; // range from -25 to +25 = 50
-            break;
-
-          case "Wide":
-            effectLevelRange = 100; // range from -50 to +50 = 100
-            break;
+      if (effectEncoderName === "pitch") {
+        const hardTuneActive = store.getActiveDevice().effects.current.hard_tune.is_enabled;
+        const encoderStyle = store.getActiveDevice().effects.current[effectEncoderName].style;
+        if (hardTuneActive) {
+          effectLevelRange = (encoderStyle === "Narrow") ? 2 : 4;
         }
       }
 
       // very high iq math that is definitely not a workaround
-      const rawCurrentLevel = (maxLevel / effectLevelRange * effectAmount) + (centerMode ? 0 : 1);
-      const currentLevel = (affectedByHardTune && hardTuneActive) ? (maxLevel / 2) * (rawCurrentLevel * 2) : rawCurrentLevel;
+      const currentLevel = (maxLevel / effectLevelRange * effectAmount) + (centerMode ? 0 : 1);
       const normalizedCurrentLevel = currentLevel > 0 ? Math.ceil(currentLevel) : Math.floor(currentLevel);
 
       if (centerMode) {


### PR DESCRIPTION
I've added a new field to the Encoders in the Utility that reports 'exact' values of the encoders, with the goal to do away with the need to try and calculate the values (which can often result in small rounding errors). The values that can come from the GoXLR are as follows:

* Reverb: 0 -> 24
* Echo: 0 -> 24
* Gender: -24 -> 24
* Pitch
  * HardTune Off: -24 -> 24
  * Hardtune On: 
    * Narrow: -1 -> 1
    * Wide: -2 -> 2 

In my testing, the visualisation display is now 100% accurate with the GoXLR, the reason for this PR is to make sure the changes aren't going to completely explode something else :)