### PR TITLE
Use secure Websocket if served via HTTPS

### DIFF
--- a/src/components/VersionCheck.vue
+++ b/src/components/VersionCheck.vue
@@ -84,7 +84,7 @@ export default {
           return false;
         }
 
-        return latest.join(".");
+        return latest.version.join(".");
       }
       return true;
     },

--- a/src/util/sockets.js
+++ b/src/util/sockets.js
@@ -244,10 +244,12 @@ we need to bounce requests across to the default port of the daemon. If we're ru
 to convert the HTTP request to a websocket request on the same port (this can be changed), so work it out here.
  */
 function getWebsocketAddress() {
+    const websocketProto = window.location.protocol.startsWith("https:") ? "wss" : "ws";
+
     if (process.env.NODE_ENV === "development") {
-        return "ws://localhost:14564/api/websocket";
+        return `ws://localhost:14564/api/websocket`;
     }
-    return "ws://" + window.location.host + "/api/websocket";
+    return `${websocketProto}://${window.location.host}/api/websocket`;
 }
 
 // Same as above, except for HTTP request...


### PR DESCRIPTION
This should allow the usage of a HTTP reverse proxy as described [here](https://github.com/GoXLR-on-Linux/goxlr-utility/issues/191)