### PR TITLE
fix: Fix double progress shown on Edge and unify looks of bar across browser

### DIFF
--- a/src/components/design/ProgressBar.vue
+++ b/src/components/design/ProgressBar.vue
@@ -52,6 +52,15 @@ export default {
 
   text-align: center;
 }
+.progress .progress-bar-inner progress::-webkit-progress-bar {
+  background-color: #252927;
+}
+.progress .progress-bar-inner progress[value]::-webkit-progress-value {
+  background-color: #59b1b6;
+}
+.progress .progress-bar-inner progress[value]::-moz-progress-bar {
+  background-color: #59b1b6;
+}
 
 .progress .progress-bar-inner div {
   position: absolute;

--- a/src/components/design/ProgressBar.vue
+++ b/src/components/design/ProgressBar.vue
@@ -52,10 +52,7 @@ export default {
 
   text-align: center;
 }
-.progress .progress-bar-inner progress[value]:after {
-  color: #fff;
-  content: attr(value)'%';
-}
+
 .progress .progress-bar-inner div {
   position: absolute;
   width: 100%;

--- a/src/components/design/modal/AccessibleModal.vue
+++ b/src/components/design/modal/AccessibleModal.vue
@@ -143,6 +143,7 @@ export default {
   text-align: center;
   color: #fff;
   overflow: hidden;
+  outline: none;
 }
 
 .modal-header div {


### PR DESCRIPTION
# Progress Bar and Modal Visual Improvements

## Changes
- Fixed double progress bar display issue on Microsoft Edge browsers
- Unified progress bar appearance across all supported browsers for consistent UX
- Removed visual outline from modal container while maintaining accessibility

## Testing
- Verified progress bar renders correctly in:
  - Microsoft Edge
  - Chrome
  - Firefox