### PR TITLE
Fix Firmware Update Localization

### DIFF
--- a/src/components/GoXLR.vue
+++ b/src/components/GoXLR.vue
@@ -59,7 +59,7 @@
     <A11yNotifications/>
 
     <AccessibleModal id="firmware_update_progress_modal" ref="firmware_update_progress_modal" width="620px" :show_footer=false :show_close=false>
-      <template v-slot:title>{{$t('message.system.firmwareUpdateButton')}}</template>
+      <template v-slot:title>{{$t('message.system.firmwareUpdate.title')}}</template>
 
       <div v-if="getFirmwareUpdateState() == 'Pause'">
         {{ $t('message.system.firmwareUpdate.updatePaused', {version: getFirmwareTargetVersion()}) }}

--- a/src/components/sections/lighting/LightingTab.vue
+++ b/src/components/sections/lighting/LightingTab.vue
@@ -71,8 +71,6 @@ export default {
 
   methods: {
     activateArea(area) {
-      console.log(area);
-
       switch (area) {
         case HighlightArea.COUGH: {
           this.loadCoughTab();

--- a/src/components/sections/system/modals/SettingsButton.vue
+++ b/src/components/sections/system/modals/SettingsButton.vue
@@ -226,7 +226,6 @@ export default {
     },
 
     setUIHandler(value) {
-      console.log(value);
       let newValue = null;
       if (value === "app") {
         newValue = this.getAppPath();
@@ -323,7 +322,6 @@ export default {
       return store.getConfig().firmware_source;
     },
     setFirmwareSource(value) {
-      console.log({"SetFirmwareSource": value});
       websocket.send_daemon_command({"SetFirmwareSource": value});
     },
 

--- a/src/lang/languages/de_DE.js
+++ b/src/lang/languages/de_DE.js
@@ -769,6 +769,7 @@ export default {
                 failed: "Bei der Aktualisierung der Firmware ist ein Fehler aufgetreten. Bitte versuche es erneut.",
 
                 changelog: "Version {version} Änderungen:",
+                title: "Installiere Firmware...",
 
                 progress: {
                     starting: "Starte...",

--- a/src/lang/languages/en_GB.js
+++ b/src/lang/languages/en_GB.js
@@ -794,6 +794,7 @@ export default {
                 failed: "Something went wrong during the firmware update. Please try again.",
 
                 changelog: "Version {version} Changelog:",
+                title: "Installing Firmware...",
 
                 progress: {
                     starting: "Starting...",


### PR DESCRIPTION
Adds localization support for the firmware update modal. Also removes two log statements that were probably leftovers from testing.