### PR TITLE
Fix firmware update button issues

### DIFF
--- a/src/components/sections/system/modals/FirmwareUpdateButton.vue
+++ b/src/components/sections/system/modals/FirmwareUpdateButton.vue
@@ -137,9 +137,19 @@ export default {
       this.$refs.firmware_update_modal.openModal(undefined, this.$refs.firmware_update_button)
     },
 
+    isLatestFirmwareAvailable() {
+      // tc-helicon took the update servers offline, so the update check is kinda useless.
+      // to prevent issues during development, we will need to check for null values here.
+      return store.getConfig().latest_firmware.Mini !== null
+          && store.getConfig().latest_firmware.Full !== null;
+    },
+
     // checks if the current firmware is older (-1), equal (0) or newer (1) than the latest firmware
     compareCurrentFirmwareToLatest() {
       if (store.getConfig() === undefined || store.getActiveDevice() === undefined)
+        return 0;
+
+      if (!this.isLatestFirmwareAvailable())
         return 0;
 
       const latestVersion = isDeviceMini()
@@ -156,8 +166,14 @@ export default {
     },
 
     getLatestFirmwareInfo() {
-      if (store.getConfig() === undefined || store.getActiveDevice() === undefined)
-        return false;
+      if (store.getConfig() === undefined || store.getActiveDevice() === undefined || !this.isLatestFirmwareAvailable()) {
+        // vue does not like null values during render.
+        // when the tc-helicon update servers are not available, we just return an empty values
+        return {
+          change_log: "",
+          version: []
+        };
+      }
 
       return isDeviceMini()
           ? store.getConfig().latest_firmware.Mini

--- a/src/components/sections/system/modals/FirmwareUpdateButton.vue
+++ b/src/components/sections/system/modals/FirmwareUpdateButton.vue
@@ -113,8 +113,8 @@ export default {
         return this.$t('message.system.firmwareUpdateButton.update'); // update if firmware is older
       else if (this.compareCurrentFirmwareToLatest() > 0)
         return this.$t('message.system.firmwareUpdateButton.downgrade'); // downgrade if firmware is newer
-      else if (this.lastCtrlKeyState && !this.lastShiftKeyState)
-        return this.$t('message.system.firmwareUpdateButton.reinstall'); // reinstall if only ctrl is pressed
+      else if (this.lastCtrlKeyState && !this.lastShiftKeyState && this.isLatestFirmwareAvailable())
+        return this.$t('message.system.firmwareUpdateButton.reinstall'); // reinstall if only ctrl is pressed and firmware servers are available
     },
 
     shouldShowUpdateButton() {

--- a/src/components/sections/system/modals/FirmwareUpdateButton.vue
+++ b/src/components/sections/system/modals/FirmwareUpdateButton.vue
@@ -168,7 +168,7 @@ export default {
     getLatestFirmwareInfo() {
       if (store.getConfig() === undefined || store.getActiveDevice() === undefined || !this.isLatestFirmwareAvailable()) {
         // vue does not like null values during render.
-        // when the tc-helicon update servers are not available, we just return an empty values
+        // when the tc-helicon update servers are not available, we just return empty values
         return {
           change_log: "",
           version: []


### PR DESCRIPTION
This is a more development focused change. It fixes an issue with the Vue.js build when the Firmware Update-Servers are not available during development.
It also disables the 'reinstall' button when the servers are not available, since it is not usable without working servers.