### PR TITLE
Add tap tempo window setting with localization support

### DIFF
--- a/src/components/sections/system/modals/DeviceSettingsButton.vue
+++ b/src/components/sections/system/modals/DeviceSettingsButton.vue
@@ -30,6 +30,11 @@
                        @change="updateSamplerFadeDuration" :label="$t('message.system.device.samplerFadeDuration')"
                        :description="$t('message.system.device.samplerFadeDurationAccessibility')"/>
 
+        <NumberSetting v-if="hasTapTempoWindow()" :value="getTapTempoWindow()" :min="1000" :max="2000" suffix="ms"
+                       @change="updateTapTempoWindow"
+                       :label="$t('message.system.device.tapTempoWindow')"
+                       :description="$t('message.system.device.tapTempoWindowAccessibility')"/>
+
         <BooleanSetting :label="$t('message.system.device.voiceDeafen')" :enabled="get_vcmaammtcm()"
                         @change="set_vcmaammtcm" :description="$t('message.system.device.voiceDeafenAccessibility')"/>
 
@@ -103,6 +108,26 @@ export default {
 
     updateSamplerFadeDuration(millis) {
       websocket.send_command(store.getActiveSerial(), {"SetSamplerFadeDuration": millis});
+    },
+
+    hasTapTempoWindow() {
+      const device = store.getActiveDevice();
+      if (!device) return false;
+      return device.settings.tap_tempo_window_ms !== undefined;
+    },
+
+    getTapTempoWindow() {
+      if (!store.getActiveDevice()) {
+        return 1500;
+      }
+      // Fallback to default if not provided by daemon
+      const value = store.getActiveDevice().settings.tap_tempo_window_ms ?? 1500;
+      // Clamp to UI-supported range
+      return Math.min(2000, Math.max(1000, value));
+    },
+
+    updateTapTempoWindow(millis) {
+      websocket.send_command(store.getActiveSerial(), {"SetTapTempoWindow": millis});
     },
 
     get_vcmaammtcm() {

--- a/src/lang/languages/de_DE.js
+++ b/src/lang/languages/de_DE.js
@@ -680,6 +680,9 @@ export default {
 
                 samplerFadeDuration: "Sampler Ausblenddauer",
                 samplerFadeDurationAccessibility: "Die Dauer in Millisekunden, die der Sampler ausgeblendet wird, wenn die Wiedergabe gestoppt wird",
+
+                tapTempoWindow: "Tap Tempo Fenster",
+                tapTempoWindowAccessibility: "Maximale Zeit zwischen Taps (in Millisekunden) für Tap-Tempo-Erkennung",
             },
 
             settingsButton: "Utility Einstellungen",

--- a/src/lang/languages/en_GB.js
+++ b/src/lang/languages/en_GB.js
@@ -705,6 +705,9 @@ export default {
 
                 samplerFadeDuration: "Sampler Fade Duration",
                 samplerFadeDurationAccessibility: "The duration in milliseconds that the sampler will fade out when playback is stopped",
+
+                tapTempoWindow: "Tap Tempo Window",
+                tapTempoWindowAccessibility: "Maximum time between taps (in milliseconds) for tap-tempo detection",
             },
 
             settingsButton: "Utility Settings",

--- a/src/lang/languages/es_ES.js
+++ b/src/lang/languages/es_ES.js
@@ -639,6 +639,9 @@ export default {
 
                 lockFaders: "Bloquear la posición de los faders al silenciar todo",
                 lockFadersAccessibility: "Evita que los faders se desplacen hacia abajo cuando está activo Silenciar Todo",
+
+                tapTempoWindow: "Ventana de Tap Tempo",
+                tapTempoWindowAccessibility: "Tiempo máximo entre toques (en milisegundos) para la detección de tempo",
             },
 
             settingsButton: "Configuración de la Utilidad",

--- a/src/lang/languages/fr_FR.js
+++ b/src/lang/languages/fr_FR.js
@@ -692,6 +692,9 @@ export default {
 
                 lockFaders: "Verrouiller les positions des curseurs lors de la mise en sourdine générale.",
                 lockFadersAccessibility: "Empêche les curseurs de descendre lorsque la mise en sourdine générale est activée.",
+
+                tapTempoWindow: "Fenêtre Tap Tempo",
+                tapTempoWindowAccessibility: "Temps maximum entre les taps (en millisecondes) pour la détection du tempo",
             },
 
             settingsButton: "Paramètres de l'Utilitaire",

--- a/src/lang/languages/it_IT.js
+++ b/src/lang/languages/it_IT.js
@@ -672,6 +672,9 @@ export default {
 
                 lockFaders: "Blocca posizioni fader quando Muta verso Tutti viene attivato",
                 lockFadersAccessibility: "Disabilita il movimento dei fader quando viene attivato Muta verso Tutti",
+
+                tapTempoWindow: "Finestra Tap Tempo",
+                tapTempoWindowAccessibility: "Tempo massimo tra i tap (in millisecondi) per il rilevamento del tempo",
             },
 
             settingsButton: "Impostazioni Utility",

--- a/src/lang/languages/nl_NL.js
+++ b/src/lang/languages/nl_NL.js
@@ -692,6 +692,9 @@ export default {
 
                 lockFaders: "Blokkeer fader posities bij dempen",
                 lockFadersAccessibility: "Zorgt ervoor dat de faders niet meer bewegen terwijl het kanaal gedempt is",
+
+                tapTempoWindow: "Tap Tempo Venster",
+                tapTempoWindowAccessibility: "Maximale tijd tussen tikken (in milliseconden) voor tempo-detectie",
             },
 
             settingsButton: "Utility Instellingen",

--- a/src/lang/languages/pl_PL.js
+++ b/src/lang/languages/pl_PL.js
@@ -692,6 +692,9 @@ export default {
 
                 lockFaders: "Zablokuj Pozycje Suwaków kiedy Wyciszasz Wszędzie",
                 lockFadersAccessibility: "Nie przesuwa suwaków na dół kiedy opcja Wyciszenia Wszędzie jest aktywna",
+
+                tapTempoWindow: "Okno Tap Tempo",
+                tapTempoWindowAccessibility: "Maksymalny czas między stuknięciami (w milisekundach) do wykrywania tempa",
             },
 
             settingsButton: "Ustawienia GoXLR Utility",

--- a/src/lang/languages/ru_RU.js
+++ b/src/lang/languages/ru_RU.js
@@ -692,6 +692,9 @@ export default {
 
                 lockFaders: "Не передвигать Фейдеры при Заглушении для Всего",
                 lockFadersAccessibility: "Не давать фейдера передвигаться вниз, когда включён Заглушить для Всего",
+
+                tapTempoWindow: "Окно Tap Tempo",
+                tapTempoWindowAccessibility: "Максимальное время между нажатиями (в миллисекундах) для определения темпа",
             },
 
             settingsButton: "Настройки Утилиты",


### PR DESCRIPTION
### summary
This pull request references my pull request on [goxlr-utility](https://github.com/GoXLR-on-Linux/goxlr-utility/pull/225), and adds support for configuring the "Tap Tempo Window" setting in the device settings modal, allowing users to adjust the maximum time between taps for tap-tempo detection. The change introduces a new number setting in the UI and provides translations for the new setting in all supported languages.

### **Device Settings UI Enhancement:**

* Added a `NumberSetting` input for "Tap Tempo Window" in `DeviceSettingsButton.vue`, allowing users to set the tap-tempo detection window in milliseconds. The input is shown only if the device supports the setting, and values are clamped between 1000 and 2000 ms. [[1]](diffhunk://#diff-6a826c600c5795dda6676df2cc5cb59db195b177635e4f1ec661a922163bd17eR33-R37) [[2]](diffhunk://#diff-6a826c600c5795dda6676df2cc5cb59db195b177635e4f1ec661a922163bd17eR113-R132)

#### **Localization Updates:**

* Added translations for "Tap Tempo Window" and its accessibility description in all supported languages: German (`de_DE.js`), English (`en_GB.js`), Spanish (`es_ES.js`), French (`fr_FR.js`), Italian (`it_IT.js`), Dutch (`nl_NL.js`), Polish (`pl_PL.js`), and Russian (`ru_RU.js`). [[1]](diffhunk://#diff-f82b4d7fc6991f6980ff4748acc59e950436154889604d8badebf0c1b3af181bR683-R685) [[2]](diffhunk://#diff-a460bb44d5f1d151db51d69e12fb3b90705a31f95c5f3c84d9405c682f30335bR708-R710) [[3]](diffhunk://#diff-ec508dd4305789d50aa5bd8545f79bff40ba5053f8e8744277b4993bd2a9c130R642-R644) [[4]](diffhunk://#diff-2fd2c49b2edc1ea31c83a7e7e5b354f1a301117a5205a4657b5bd9c4adcab130R695-R697) [[5]](diffhunk://#diff-2fdaa1a5eef33345f541a2d4875d0a22d570169bca914284f5e85f4f4a807e3aR675-R677) [[6]](diffhunk://#diff-eddd36ead473be5329815a8feabc9510f25283a040c1455e5aaa89678c22f52cR695-R697) [[7]](diffhunk://#diff-e97da3dbfa303c5871286f6b262c70cd29d0815b51ade451060c9d53cf8f9a8cR695-R697) [[8]](diffhunk://#diff-aa076815e9b9449365312775a0cf350cf038c24610b805198138f1cbdc6c6178R695-R697)